### PR TITLE
FIX  #14 - Remove unintended warning message when calling 'kedro mlfow init' command

### DIFF
--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -78,7 +78,7 @@ def test_mlflow_commands_inside_initialized_kedro_project(
 ):
     monkeypatch.chdir(tmp_path / "fake-project")
     # launch the command to initialize the project
-    subprocess.call(["kedro", "mlflow", "init", "--force"])
+    subprocess.call(["kedro", "mlflow", "init"])
     cli_runner = CliRunner()
     result = cli_runner.invoke(cli_mlflow)
     assert {"init", "ui"} == set(extract_cmd_from_help(result.output))


### PR DESCRIPTION
Fix this bug which is annoying with a false warning (even if the function call was ok)