### PR TITLE
FIX #81 - Remove deprecated arguments from MlflowNodeHook constructor

### DIFF
--- a/kedro_mlflow/framework/hooks/node_hook.py
+++ b/kedro_mlflow/framework/hooks/node_hook.py
@@ -9,9 +9,7 @@ from kedro_mlflow.framework.context import get_mlflow_config
 
 
 class MlflowNodeHook:
-    def __init__(
-        self, flatten_dict_params: bool = False, recursive: bool = True, sep: str = "."
-    ):
+    def __init__(self):
         config = get_mlflow_config()
         self.flatten = config.node_hook_opts["flatten_dict_params"]
         self.recursive = config.node_hook_opts["recursive"]


### PR DESCRIPTION
## Description
Fix the issue #81.

## Development notes
Remove the lines from the constructor

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- *N/A* Update the documentation to reflect the code changes
- *N/A* Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- *N/A* Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
