### PR TITLE
FIX #83 - Check input_name when set in PipelineML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove `conda_env` and `model_name` arguments from `MlflowPipelineHook` and add them to `PipelineML` and `pipeline_ml`. This is necessary for incoming hook auto-discovery in future release and it enables having multiple `PipelineML` in the same project ([#58](https://github.com/Galileo-Galilei/kedro-mlflow/pull/58)). This mechanically fixes [#54](https://github.com/Galileo-Galilei/kedro-mlflow/issues/54) by making `conda_env` path absolute for airflow suppport.
 - `flatten_dict_params`, `recursive` and `sep` arguments of the `MlflowNodeHook` are moved to the `mlflow.yml` config file to prepare plugin auto registration. This also modifies the `run.py` template (to remove the args) and the `mlflow.yml` keys to add a `hooks` entry. ([#59](https://github.com/Galileo-Galilei/kedro-mlflow/pull/59))
 - Rename CI workflow to `test` ([#57](https://github.com/Galileo-Galilei/kedro-mlflow/issues/57), [#68](https://github.com/Galileo-Galilei/kedro-mlflow/pull/68))
+- The `input_name` attributes of `PipelineML` is now a python property and makes a check at setting time to prevent setting an invalid value. The check ensures that `input_name` is a valid input of the `inference` pipeline.
 
 
 ### Deprecated

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -79,8 +79,16 @@ class PipelineML(Pipeline):
         self.conda_env = conda_env
         self.model_name = model_name
 
-        self._check_input_name(input_name)
         self.input_name = input_name
+
+    @property
+    def input_name(self) -> str:
+        return self._input_name
+
+    @input_name.setter
+    def input_name(self, name: str) -> None:
+        self._check_input_name(name)
+        self._input_name = name
 
     def extract_pipeline_catalog(self, catalog: DataCatalog) -> DataCatalog:
         sub_catalog = DataCatalog()
@@ -134,10 +142,10 @@ class PipelineML(Pipeline):
 
     def _check_input_name(self, input_name: str) -> str:
         allowed_names = self.inference.inputs()
-        pp_allowed_names = "\n - ".join(allowed_names)
+        pp_allowed_names = "\n    - ".join(allowed_names)
         if input_name not in allowed_names:
             raise KedroMlflowPipelineMLInputsError(
-                f"input_name='{input_name}' but it must be an input of inference, i.e. one of: {pp_allowed_names}"
+                f"input_name='{input_name}' but it must be an input of 'inference', i.e. one of: \n    - {pp_allowed_names}"
             )
         else:
             free_inputs_set = (

--- a/tests/pipeline/test_pipeline_ml.py
+++ b/tests/pipeline/test_pipeline_ml.py
@@ -119,24 +119,25 @@ def dummy_context(tmp_path, config_dir, mocker):
     # Disable logging.config.dictConfig in KedroContext._setup_logging as
     # it changes logging.config and affects other unit tests
     mocker.patch("logging.config.dictConfig")
-
-    return DummyContext(tmp_path.as_posix())
+    dummy_context = DummyContext(tmp_path.as_posix())
+    return dummy_context
 
 
 @pytest.fixture
 def dummy_catalog():
-    return DataCatalog(
+    dummy_catalog = DataCatalog(
         {
             "raw_data": MemoryDataSet(),
             "data": MemoryDataSet(),
             "model": CSVDataSet("fake/path/to/model.csv"),
         }
     )
+    return dummy_catalog
 
 
 @pytest.fixture
 def catalog_with_encoder():
-    return DataCatalog(
+    catalog_with_encoder = DataCatalog(
         {
             "raw_data": MemoryDataSet(),
             "data": MemoryDataSet(),
@@ -144,6 +145,7 @@ def catalog_with_encoder():
             "model": CSVDataSet("fake/path/to/model.csv"),
         }
     )
+    return catalog_with_encoder
 
 
 @pytest.mark.parametrize(
@@ -332,3 +334,11 @@ def test_decorate(pipeline_ml_with_tag):
 
     new_pl = pipeline_ml_with_tag.decorate(fake_dec)
     assert all([fake_dec in node._decorators for node in new_pl.nodes])
+
+
+def test_invalid_input_name(pipeline_ml_with_tag):
+    with pytest.raises(
+        KedroMlflowPipelineMLInputsError,
+        match="input_name='whoops_bad_name' but it must be an input of 'inference'",
+    ):
+        pipeline_ml_with_tag.input_name = "whoops_bad_name"


### PR DESCRIPTION
## Description
FIX #83 - Check input_name when set in PipelineML

## Development notes
- Decorate `input_name` with `@property`
- Ensure 100% test coverage for `pipeline_ml`

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- *N/A* Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
