### PR TITLE
FIX #85 - Rename pipeline_ml as pipeline_ml_factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Deprecated
 
 - Deprecate `MlflowDataSet` which is renamed as `MlflowArtifactDataSet` for consistency with the other datasets. It will raise a `DeprecationWarning` in this realease, and will be totally supressed in next minor release. Please update your `catalog.yml` entries accordingly as soon as possible. ([#63](https://github.com/Galileo-Galilei/kedro-mlflow/issues/63))
+- Deprecate `pipeline_ml` which is renamed as `pipeline_ml_factory` to avoid confusion between a `PipelineML` instance and the helper function to create `PipelineMl` instances from Kedro `Pipeline`s.
 
 ## [0.2.1] - 2018-08-06
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The documentation contains:
 Some frequently asked questions on more advanced features:
 - You want to log additional metrics to the run? -> [Try ``MlflowMetricsDataSet``](https://kedro-mlflow.readthedocs.io/en/latest/source/03_tutorial/07_version_metrics.html) !
 - You want to log nice dataviz of your pipeline that you register with ``MatplotlibWriter``? -> [Try ``MlflowArtifactDataSet`` to log any local files (.png, .pkl, .csv...) *automagically*](https://kedro-mlflow.readthedocs.io/en/latest/source/02_hello_world_example/02_first_steps.html#artifacts)!
-- You want to create easily an API to share your awesome model to anyone? -> [See if ``pipeline_ml`` can fit your needs](https://github.com/Galileo-Galilei/kedro-mlflow/issues/16)
+- You want to create easily an API to share your awesome model to anyone? -> [See if ``pipeline_ml_factory`` can fit your needs](https://github.com/Galileo-Galilei/kedro-mlflow/issues/16)
 - You want to do something that is not straigthforward with current implementation? Open an issue, and let's see what happens!
 
 # Can I contribute?

--- a/docs/source/01_introduction/02_motivation.md
+++ b/docs/source/01_introduction/02_motivation.md
@@ -1,10 +1,13 @@
 # Motivation
+
 ## When should I use kedro-mlflow?
+
 Basically, you should use ``kedro-mlflow`` in **any ``Kedro`` project which involves machine learning** / deep learning. As stated in the [introduction](./01_introduction.md), ``Kedro``'s current versioning (as of version ``0.16.1``) is not sufficient for machine learning projects: it lacks a UI and a ``run`` management system. Besides, the ``KedroPipelineModel`` ability to serve a kedro pipeline as an API or a batch in one line of code is a great addition for collaboration and transition to production.
 
 If you do not use ``Kedro`` or if you do pure data manipulation which do not involve machine learning, this plugin is not what you are seeking for ;)
 
 ## Why should I use kedro-mlflow ?
+
 ### Benchmark of existing solutions
 
 This paragraph gives a (quick) overview of existing solutions for mlflow integration inside Kedro projects.
@@ -36,7 +39,7 @@ Above implementations have the advantage of being very straightforward and *mlfl
 |Logging artifacts            |``catalog.yml``         |``MlflowArtifactDataSet``       |
 |Logging models               |NA                      |NA                      |
 |Logging metrics              |``catalog.yml``         |``MlflowMetricsDataSet``|
-|Logging Pipeline as model    |``pipeline.py``         |``KedroPipelineModel`` and ``pipeline_ml``|
+|Logging Pipeline as model    |``pipeline.py``         |``KedroPipelineModel`` and ``pipeline_ml_factory``|
 
 In the current version (``kedro_mlflow=0.2.0``), kedro-mlflow does not provide interface to log metrics, set tags or log models outside a Kedro ``Pipeline``. These decisions are subject to debate and design decisions (for instance, metrics are often updated in a loop during each epoch / training iteration and it does not always make sense to register the metric between computation steps, e.g. as a an I/O operation after a node run).
 

--- a/docs/source/05_python_objects/03_Pipelines.md
+++ b/docs/source/05_python_objects/03_Pipelines.md
@@ -1,9 +1,9 @@
 # Pipelines
-## ``PipelineML`` and ``pipeline_ml``
+## ``PipelineML`` and ``pipeline_ml_factory``
 
 ``PipelineML`` is a new class which extends ``Pipeline`` and enable to bind two pipelines (one of training, one of inference) together. This class comes with a ``KedroPipelineModel`` class for logging it in mlflow. A pipeline logged as a mlflow model can be served using ``mlflow models serve`` and ``mlflow models predict`` command.  
 
-The ``PipelineML`` class is not intended to be used directly. A ``pipeline_ml`` factory is provided for user friendly interface.
+The ``PipelineML`` class is not intended to be used directly. A ``pipeline_ml_factory`` factory is provided for user friendly interface.
 
 Example within kedro template:
 
@@ -14,8 +14,8 @@ from PYTHON_PACKAGE.pipelines import data_science as ds
 
 def create_pipelines(**kwargs) -> Dict[str, Pipeline]:
     data_science_pipeline = ds.create_pipeline()
-    training_pipeline = pipeline_ml(training=data_science_pipeline.only_nodes_with_tags("training"), # or whatever your logic is for filtering
-                                    inference=data_science_pipeline.only_nodes_with_tags("inference"))
+    training_pipeline = pipeline_ml_factory(training=data_science_pipeline.only_nodes_with_tags("training"), # or whatever your logic is for filtering
+                                            inference=data_science_pipeline.only_nodes_with_tags("inference"))
 
     return {
         "ds": data_science_pipeline,

--- a/kedro_mlflow/framework/hooks/pipeline_hook.py
+++ b/kedro_mlflow/framework/hooks/pipeline_hook.py
@@ -12,7 +12,7 @@ from kedro.versioning.journal import _git_sha
 from kedro_mlflow.framework.context import get_mlflow_config
 from kedro_mlflow.io import MlflowMetricsDataSet
 from kedro_mlflow.mlflow import KedroPipelineModel
-from kedro_mlflow.pipeline.pipeline_ml import PipelineML
+from kedro_mlflow.pipeline.pipeline_ml_factory import PipelineML
 from kedro_mlflow.utils import _parse_requirements
 
 

--- a/kedro_mlflow/pipeline/__init__.py
+++ b/kedro_mlflow/pipeline/__init__.py
@@ -1,5 +1,5 @@
-from .modular_pipeline_ml import pipeline_ml
 from .pipeline_ml import (
     KedroMlflowPipelineMLDatasetsError,
     KedroMlflowPipelineMLInputsError,
 )
+from .pipeline_ml_factory import pipeline_ml, pipeline_ml_factory

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -5,13 +5,13 @@ from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 
-MSG_NOT_IMPLEMENTED = "This method is not implemented because it does not make sens for 'PipelineML'. Manipulate directly the training pipeline and recreate the 'PipelineML' with 'pipeline_ml' factory"
+MSG_NOT_IMPLEMENTED = "This method is not implemented because it does not make sens for 'PipelineML'. Manipulate directly the training pipeline and recreate the 'PipelineML' with 'pipeline_ml_factory' factory"
 
 
 class PipelineML(Pipeline):
     """
     IMPORTANT NOTE : THIS CLASS IS NOT INTENDED TO BE USED DIRECTLY IN A KEDRO PROJECT. YOU SHOULD USE
-    ``pipeline_ml`` FUNCTION FOR MODULAR PIPELINE WHICH IS MORE FLEXIBLE AND USER FRIENDLY.
+    ``pipeline_ml_factory`` FUNCTION FOR MODULAR PIPELINE WHICH IS MORE FLEXIBLE AND USER FRIENDLY.
     SEE INSERT_DOC_URL
 
     A ``PipelineML`` is a kedro ``Pipeline`` which we assume is a "training" (in the machine learning way)

--- a/kedro_mlflow/pipeline/pipeline_ml_factory.py
+++ b/kedro_mlflow/pipeline/pipeline_ml_factory.py
@@ -1,19 +1,22 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
+from warnings import warn
 
 from kedro.pipeline import Pipeline
 
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
 
 
-def pipeline_ml(
+def pipeline_ml_factory(
     training: Pipeline,
     inference: Pipeline,
     input_name: str = None,
     conda_env: Optional[Union[str, Path, Dict[str, Any]]] = None,
     model_name: Optional[str] = "model",
 ) -> PipelineML:
-    """[summary]
+    """This function is a helper to create `PipelineML`
+    object directly from two Kedro `Pipelines` (one of
+    training and one of inference) .
 
     Args:
         training (Pipeline): The `Pipeline` object that creates
@@ -60,3 +63,24 @@ def pipeline_ml(
         model_name=model_name,
     )
     return pipeline
+
+
+def pipeline_ml(
+    training: Pipeline,
+    inference: Pipeline,
+    input_name: str = None,
+    conda_env: Optional[Union[str, Path, Dict[str, Any]]] = None,
+    model_name: Optional[str] = "model",
+) -> PipelineML:
+
+    deprecation_msg = (
+        "'pipeline_ml' is now deprecated and "
+        "has been renamed 'pipeline_ml_factory' "
+        "in 'kedro-mlflow>=0.3.0'. "
+        "\nPlease change your 'pipeline.py' or 'hooks.py' entries "
+        "accordingly, since 'pipeline_ml' will be removed in next release."
+    )
+
+    warn(deprecation_msg, DeprecationWarning, stacklevel=2)
+
+    return pipeline_ml_factory(training, inference, input_name, conda_env, model_name)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 mlflow>=1.0.0, <2.0.0
-kedro>=0.16.0, <=0.16.4  # 0.16.5 breaks pipeline_ml, template and hooks test
+kedro>=0.16.0, <=0.16.4  # 0.16.5 breaks pipeline_ml_factory, template and hooks test

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -17,7 +17,7 @@ from kedro_mlflow.framework.hooks.pipeline_hook import (
     _generate_kedro_command,
 )
 from kedro_mlflow.io import MlflowMetricsDataSet
-from kedro_mlflow.pipeline import pipeline_ml
+from kedro_mlflow.pipeline import pipeline_ml_factory
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
 
 
@@ -159,7 +159,7 @@ def dummy_pipeline():
 @pytest.fixture
 def dummy_pipeline_ml(dummy_pipeline, env_from_dict):
 
-    dummy_pipeline_ml = pipeline_ml(
+    dummy_pipeline_ml = pipeline_ml_factory(
         training=dummy_pipeline.only_nodes_with_tags("training"),
         inference=dummy_pipeline.only_nodes_with_tags("inference"),
         input_name="raw_data",

--- a/tests/mlflow/test_kedro_pipeline_model.py
+++ b/tests/mlflow/test_kedro_pipeline_model.py
@@ -7,7 +7,7 @@ from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
 
 from kedro_mlflow.mlflow import KedroPipelineModel
-from kedro_mlflow.pipeline import pipeline_ml
+from kedro_mlflow.pipeline import pipeline_ml_factory
 
 
 def preprocess_fun(data):
@@ -42,7 +42,7 @@ def pipeline_ml_obj():
         ]
     )
 
-    pipeline_ml_obj = pipeline_ml(
+    pipeline_ml_obj = pipeline_ml_factory(
         training=full_pipeline.only_nodes_with_tags("training"),
         inference=full_pipeline.only_nodes_with_tags("inference"),
         input_name="raw_data",

--- a/tests/pipeline/test_pipeline_ml.py
+++ b/tests/pipeline/test_pipeline_ml.py
@@ -9,6 +9,7 @@ from kedro_mlflow.pipeline import (
     KedroMlflowPipelineMLDatasetsError,
     KedroMlflowPipelineMLInputsError,
     pipeline_ml,
+    pipeline_ml_factory,
 )
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
 
@@ -52,7 +53,7 @@ def pipeline_with_tag():
 
 @pytest.fixture
 def pipeline_ml_with_tag(pipeline_with_tag):
-    pipeline_ml_with_tag = pipeline_ml(
+    pipeline_ml_with_tag = pipeline_ml_factory(
         training=pipeline_with_tag,
         inference=Pipeline(
             [node(func=predict_fun, inputs=["model", "data"], outputs="predictions")]
@@ -60,6 +61,23 @@ def pipeline_ml_with_tag(pipeline_with_tag):
         input_name="data",
     )
     return pipeline_ml_with_tag
+
+
+def test_raise_deprecation_warning_pipeline_ml(pipeline_with_tag):
+    with pytest.deprecated_call():
+        pipeline_ml(
+            training=pipeline_with_tag,
+            inference=Pipeline(
+                [
+                    node(
+                        func=predict_fun,
+                        inputs=["model", "data"],
+                        outputs="predictions",
+                    )
+                ]
+            ),
+            input_name="data",
+        )
 
 
 @pytest.fixture
@@ -98,7 +116,7 @@ def pipeline_ml_with_intermediary_artifacts():
             ),
         ]
     )
-    pipeline_ml_with_tag = pipeline_ml(
+    pipeline_ml_with_tag = pipeline_ml_factory(
         training=full_pipeline.only_nodes_with_tags("training"),
         inference=full_pipeline.only_nodes_with_tags("inference"),
         input_name="data",


### PR DESCRIPTION
## Description
Deprecate the confusing name of `pipeline_ml` function.

## Development notes
- Renamed `pipeline_ml` as `pipeline_ml_factory` everywhere (code, tests, docs)
- Add a deprecation warning to `pipeline_ml`

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
