### PR TITLE
FIX #88 - Initialise bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,5 @@
+[bumpversion]
+current_version = 0.2.1
+
+[bumpversion:file:setup.py]
+[bumpversion:file:kedro_mlflow/__init__.py]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,7 +30,7 @@ jobs:
       id: bump_version
       run: |
         pip install bump2version
-        bump2version ${{ github.event.inputs.version_part }} $PYTHON_PACKAGE/__init__.py
+        bump2version ${{ github.event.inputs.version_part }}
         echo "::set-output name=package_version::$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')"
     - name: Update the CHANGELOG according to 'Keep a Changelog' guidelines
       uses: thomaseizinger/keep-a-changelog-new-release@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update README (add badges for readibility, add a "main contributors" section to give credit, fix typo in install command, link to milestones for more up-to-date priorities) ([#57](https://github.com/Galileo-Galilei/kedro-mlflow/issues/57), [#68](https://github.com/Galileo-Galilei/kedro-mlflow/pull/68))
 - Fix bug in CI deployment workflow and rename it to `publish` ([#57](https://github.com/Galileo-Galilei/kedro-mlflow/issues/57), [#68](https://github.com/Galileo-Galilei/kedro-mlflow/pull/68))
 - Fix a bug in `MlflowDataSet` which sometimes failed to log on remote storage (S3, Azure Blob storage) with underlying `log_artifacts` when the kedro's `AbstractDataset._filepath` was a `pathlib.PurePosixPath` object instead of a string ([#74](https://github.com/Galileo-Galilei/kedro-mlflow/issues/74)).
+- Add a CI for release candidate creation and use actions to enforce semantic versioning and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,9 @@
 import pathlib
-import re
 
 from setuptools import find_packages, setup
 
 NAME = "kedro_mlflow"
 HERE = pathlib.Path(__file__).parent
-
-# get package version
-with open((HERE / NAME / "__init__.py").as_posix(), encoding="utf-8") as file_handler:
-    result = re.search(r'__version__ *= *["\']([^"\']+)', file_handler.read())
-
-    if not result:
-        raise ValueError("Can't find the version in kedro/__init__.py")
-
-    VERSION = result.group(1)
 
 
 def _parse_requirements(path, encoding="utf-8"):
@@ -36,7 +26,7 @@ with open((HERE / "README.md").as_posix(), encoding="utf-8") as file_handler:
 
 setup(
     name=NAME,
-    version=VERSION,
+    version="0.2.1",  # this will be bumped automatically by bump2version
     description="A kedro-plugin to use mlflow in your kedro projects",
     license="Apache Software License (Apache 2.0)",
     long_description=README,


### PR DESCRIPTION
## Description
Fix bump2version lack of initialisation

## Development notes
- Add a `.bumpversion.cfg` file with the current version( 0.2.1) and the files to update.
- Put a raw string for version in setup.py
- simplify workflow command which does not need the file to update

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [N/A Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
