### PR TITLE
FIX #66 - accessing project context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+-
+
+### Fixed
+
+- `get_mlflow_config` now uses the kedro context config_loader to get configs (#66). This indirectly solves the following issues:
+    -  `get_mlflow_config` now works in interactive mode if `load_context` is called  with a path different from the working directory (#30)
+    - kedro_mlflow now works fine with kedro jupyter notebook independently of the working directory (#64)
+    - You can use global variables in `mlflow.yml` which  is now properly parsed if you use a `TemplatedConfigLoader`  (#72)
+- `mlflow init` is now getting conf path from context.CONF_ROOT instead of hardcoded conf folder. This makes the package robust to Kedro changes.
+
+### Changed
+
+- `MlflowNodeHook` have now a before_pipeline_run hook which stores the ProjectContext and enable to retrieve configuration.
+
 ## [0.3.0] - 2020-10-11
 
 ### Added

--- a/kedro_mlflow/framework/context/mlflow_context.py
+++ b/kedro_mlflow/framework/context/mlflow_context.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from kedro.config import ConfigLoader
+from kedro.framework.context import KedroContext
 
 from kedro_mlflow.framework.context.config import KedroMlflowConfig
 
@@ -8,16 +6,9 @@ from kedro_mlflow.framework.context.config import KedroMlflowConfig
 # this could be a read-only property in the context
 # with a @property decorator
 # but for consistency with hook system, it is an external function
-def get_mlflow_config(project_path=None, env="local"):
-    if project_path is None:
-        project_path = Path.cwd()
-    project_path = Path(project_path)
-    conf_paths = [
-        str(project_path / "conf" / "base"),
-        str(project_path / "conf" / env),
-    ]
-    config_loader = ConfigLoader(conf_paths=conf_paths)
-    conf_mlflow_yml = config_loader.get("mlflow*", "mlflow*/**")
-    conf_mlflow = KedroMlflowConfig(project_path=project_path)
+def get_mlflow_config(context: KedroContext):
+
+    conf_mlflow_yml = context.config_loader.get("mlflow*", "mlflow*/**")
+    conf_mlflow = KedroMlflowConfig(context.project_path)
     conf_mlflow.from_dict(conf_mlflow_yml)
     return conf_mlflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Dict
 
@@ -49,7 +50,45 @@ def config_dir(tmp_path):
         credentials = tmp_path / "conf" / env / "credentials.yml"
         logging = tmp_path / "conf" / env / "logging.yml"
         parameters = tmp_path / "conf" / env / "parameters.yml"
+        globals_yaml = tmp_path / "conf" / env / "globals.yml"
+        kedro_yaml = tmp_path / ".kedro.yml"
         _write_yaml(catalog, dict())
         _write_yaml(parameters, dict())
+        _write_yaml(globals_yaml, dict())
         _write_yaml(credentials, dict())
-        _write_yaml(logging, _get_local_logging_config())
+        _write_yaml(logging, _get_local_logging_config()),
+
+    _write_yaml(
+        kedro_yaml,
+        dict(
+            {
+                "context_path": "dummy_package.run.ProjectContext",
+                "project_name": "dummy_package",
+                "project_version": "0.16.4",
+                "package_name": "dummy_package",
+            }
+        ),
+    )
+
+    os.mkdir(tmp_path / "src")
+    os.mkdir(tmp_path / "src" / "dummy_package")
+    with open(tmp_path / "src" / "dummy_package" / "run.py", "w") as f:
+        f.writelines(
+            [
+                "from kedro.framework.context import KedroContext\n",
+                "from kedro.config import TemplatedConfigLoader \n"
+                "class ProjectContext(KedroContext):\n",
+                "    project_name = 'dummy_package'\n",
+                "    project_version = '0.16.4'\n",
+                "    package_name = 'dummy_package'\n",
+            ]
+        )
+        f.writelines(
+            [
+                "    def _create_config_loader(self, conf_paths):\n",
+                "        return TemplatedConfigLoader(\n",
+                "        conf_paths,\n",
+                "        globals_pattern='globals.yml'\n",
+                "        )\n",
+            ]
+        )

--- a/tests/framework/context/test_mlflow_context.py
+++ b/tests/framework/context/test_mlflow_context.py
@@ -1,4 +1,5 @@
 import yaml
+from kedro.framework.context import load_context
 
 from kedro_mlflow.framework.context import get_mlflow_config
 
@@ -7,14 +8,16 @@ from kedro_mlflow.framework.context import get_mlflow_config
 #         get_mlflow_config(project_path=tmp_path,env="local")
 
 
+def _write_yaml(filepath, config):
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    yaml_str = yaml.dump(config)
+    filepath.write_text(yaml_str)
+
+
 def test_get_mlflow_config(mocker, tmp_path, config_dir):
     # config_with_base_mlflow_conf is a pytest.fixture in conftest
+    mocker.patch("logging.config.dictConfig")
     mocker.patch("kedro_mlflow.utils._is_kedro_project", return_value=True)
-
-    def _write_yaml(filepath, config):
-        filepath.parent.mkdir(parents=True, exist_ok=True)
-        yaml_str = yaml.dump(config)
-        filepath.write_text(yaml_str)
 
     _write_yaml(
         tmp_path / "conf" / "base" / "mlflow.yml",
@@ -35,4 +38,37 @@ def test_get_mlflow_config(mocker, tmp_path, config_dir):
             "node": {"flatten_dict_params": True, "recursive": False, "sep": "-"}
         },
     }
-    assert get_mlflow_config(project_path=tmp_path, env="local").to_dict() == expected
+    context = load_context(tmp_path)
+    assert get_mlflow_config(context).to_dict() == expected
+
+
+def test_mlflow_config_with_templated_config(mocker, tmp_path, config_dir):
+
+    _write_yaml(
+        tmp_path / "conf" / "base" / "mlflow.yml",
+        dict(
+            mlflow_tracking_uri="${mlflow_tracking_uri}",
+            experiment=dict(name="fake_package", create=True),
+            run=dict(id="123456789", name="my_run", nested=True),
+            ui=dict(port="5151", host="localhost"),
+            hooks=dict(node=dict(flatten_dict_params=True, recursive=False, sep="-")),
+        ),
+    )
+
+    _write_yaml(
+        tmp_path / "conf" / "base" / "globals.yml",
+        dict(mlflow_tracking_uri="testruns"),
+    )
+
+    expected = {
+        "mlflow_tracking_uri": (tmp_path / "testruns").as_uri(),
+        "experiments": {"name": "fake_package", "create": True},
+        "run": {"id": "123456789", "name": "my_run", "nested": True},
+        "ui": {"port": "5151", "host": "localhost"},
+        "hooks": {
+            "node": {"flatten_dict_params": True, "recursive": False, "sep": "-"}
+        },
+    }
+
+    context = load_context(tmp_path)
+    assert get_mlflow_config(context).to_dict() == expected

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -1,12 +1,21 @@
+from pathlib import Path
+from typing import Dict
+
 import mlflow
 import pytest
+import yaml
 from kedro.io import DataCatalog, MemoryDataSet
-from kedro.pipeline import node
+from kedro.pipeline import Pipeline, node
 from mlflow.tracking import MlflowClient
 
-from kedro_mlflow.framework.context.config import KedroMlflowConfig
 from kedro_mlflow.framework.hooks import MlflowNodeHook
 from kedro_mlflow.framework.hooks.node_hook import flatten_dict
+
+
+def _write_yaml(filepath: Path, config: Dict):
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    yaml_str = yaml.dump(config)
+    filepath.write_text(yaml_str)
 
 
 def test_flatten_dict_non_nested():
@@ -38,27 +47,27 @@ def test_flatten_dict_nested_2_levels():
     }
 
 
-@pytest.mark.parametrize(
-    "flatten_dict_params,expected",
-    [
-        (True, {"param1": "1", "parameters-param1": "1", "parameters-param2": "2"}),
-        (False, {"param1": "1", "parameters": "{'param1': 1, 'param2': 2}"}),
-    ],
-)
-def test_node_hook_logging(tmp_path, mocker, flatten_dict_params, expected):
+@pytest.fixture
+def dummy_run_params(tmp_path):
+    dummy_run_params = {
+        "run_id": "",
+        "project_path": tmp_path.as_posix(),
+        "env": "local",
+        "kedro_version": "0.16.4",
+        "tags": [],
+        "from_nodes": [],
+        "to_nodes": [],
+        "node_names": [],
+        "from_inputs": [],
+        "load_versions": [],
+        "pipeline_name": "my_cool_pipeline",
+        "extra_params": [],
+    }
+    return dummy_run_params
 
-    mocker.patch("kedro_mlflow.utils._is_kedro_project", return_value=True)
-    config = KedroMlflowConfig(
-        project_path=tmp_path,
-        node_hook_opts={"flatten_dict_params": flatten_dict_params, "sep": "-"},
-    )
-    # the function is imported inside the other file antd this is the file to patch
-    # see https://stackoverflow.com/questions/30987973/python-mock-patch-doesnt-work-as-expected-for-public-method
-    mocker.patch(
-        "kedro_mlflow.framework.hooks.node_hook.get_mlflow_config", return_value=config
-    )
-    mlflow_node_hook = MlflowNodeHook()
 
+@pytest.fixture
+def dummy_node():
     def fake_fun(arg1, arg2, arg3):
         return None
 
@@ -67,6 +76,21 @@ def test_node_hook_logging(tmp_path, mocker, flatten_dict_params, expected):
         inputs={"arg1": "params:param1", "arg2": "foo", "arg3": "parameters"},
         outputs="out",
     )
+
+    return node_test
+
+
+@pytest.fixture
+def dummy_pipeline(dummy_node):
+
+    dummy_pipeline = Pipeline([dummy_node])
+
+    return dummy_pipeline
+
+
+@pytest.fixture
+def dummy_catalog():
+
     catalog = DataCatalog(
         {
             "params:param1": 1,
@@ -75,14 +99,94 @@ def test_node_hook_logging(tmp_path, mocker, flatten_dict_params, expected):
             "parameters": {"param1": 1, "param2": 2},
         }
     )
-    node_inputs = {v: catalog._data_sets.get(v) for k, v in node_test._inputs.items()}
+
+    return catalog
+
+
+def test_pipeline_run_hook_getting_configs(
+    tmp_path, config_dir, monkeypatch, dummy_run_params, dummy_pipeline, dummy_catalog
+):
+
+    monkeypatch.chdir(tmp_path)
+
+    _write_yaml(
+        tmp_path / "conf" / "base" / "mlflow.yml",
+        dict(
+            hooks=dict(node=dict(flatten_dict_params=True, recursive=False, sep="-")),
+        ),
+    ),
+
+    mlflow_node_hook = MlflowNodeHook()
+    mlflow_node_hook.before_pipeline_run(
+        run_params=dummy_run_params, pipeline=dummy_pipeline, catalog=dummy_catalog
+    )
+
+    assert (
+        mlflow_node_hook.flatten,
+        mlflow_node_hook.recursive,
+        mlflow_node_hook.sep,
+    ) == (True, False, "-")
+
+
+@pytest.mark.parametrize(
+    "flatten_dict_params,expected",
+    [
+        (True, {"param1": "1", "parameters-param1": "1", "parameters-param2": "2"}),
+        (False, {"param1": "1", "parameters": "{'param1': 1, 'param2': 2}"}),
+    ],
+)
+def test_node_hook_logging(
+    tmp_path,
+    mocker,
+    monkeypatch,
+    dummy_run_params,
+    dummy_catalog,
+    dummy_pipeline,
+    dummy_node,
+    config_dir,
+    flatten_dict_params,
+    expected,
+):
+
+    mocker.patch("logging.config.dictConfig")
+    mocker.patch("kedro_mlflow.utils._is_kedro_project", return_value=True)
+    monkeypatch.chdir(tmp_path)
+    # config = KedroMlflowConfig(
+    #     project_path=tmp_path,
+    #     node_hook_opts={"flatten_dict_params": flatten_dict_params, "sep": "-"},
+    # )
+    # # the function is imported inside the other file antd this is the file to patch
+    # # see https://stackoverflow.com/questions/30987973/python-mock-patch-doesnt-work-as-expected-for-public-method
+    # mocker.patch(
+    #     "kedro_mlflow.framework.hooks.node_hook.get_mlflow_config", return_value=config
+    # )
+
+    _write_yaml(
+        tmp_path / "conf" / "base" / "mlflow.yml",
+        dict(
+            hooks=dict(
+                node=dict(
+                    flatten_dict_params=flatten_dict_params, recursive=False, sep="-"
+                )
+            ),
+        ),
+    ),
+
+    mlflow_node_hook = MlflowNodeHook()
+
+    node_inputs = {
+        v: dummy_catalog._data_sets.get(v) for k, v in dummy_node._inputs.items()
+    }
 
     mlflow_tracking_uri = (tmp_path / "mlruns").as_uri()
     mlflow.set_tracking_uri(mlflow_tracking_uri)
     with mlflow.start_run():
+        mlflow_node_hook.before_pipeline_run(
+            run_params=dummy_run_params, pipeline=dummy_pipeline, catalog=dummy_catalog
+        )
         mlflow_node_hook.before_node_run(
-            node=node_test,
-            catalog=catalog,
+            node=dummy_node,
+            catalog=dummy_catalog,
             inputs=node_inputs,
             is_async=False,
             run_id="132",

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -4,7 +4,7 @@ import mlflow
 import pytest
 import yaml
 from kedro.extras.datasets.pickle import PickleDataSet
-from kedro.framework.context import KedroContext
+from kedro.framework.context import KedroContext, load_context
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
 from kedro.runner import SequentialRunner
@@ -264,7 +264,8 @@ def test_mlflow_pipeline_hook_with_different_pipeline_types(
         run_params=dummy_run_params, pipeline=pipeline_to_run, catalog=dummy_catalog
     )
     # test : parameters should have been logged
-    mlflow_conf = get_mlflow_config(tmp_path)
+    context = load_context(tmp_path)
+    mlflow_conf = get_mlflow_config(context)
     mlflow_client = MlflowClient(mlflow_conf.mlflow_tracking_uri)
     run_data = mlflow_client.get_run(run_id).data
     # all run_params are recorded as tags


### PR DESCRIPTION
closes #66  #30 #72

## Description
This PR intend to fix mlflow configs related issues.

## Development notes

Some important changes :

* kedro-mlflow can now access to project context properties. That decouple the plugin from the template.
We used this access to change get_mlflow_config signature, the test have been updated accordignately.

* I add a .kedro.yml file, src folder and run.py file to the kedro project fixture for tests running in kedro 0.16.5

For more details, see changes.

Checklist

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
