### PR TITLE
FIX #105 - Remove deprecated pipeline_ml and MlflowDataSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@
 
 ### Removed
 
-- `kedro mlflow init` command is no longer declaring hooks in `run.py`. You must now [register your hooks manually](docs/source/03_tutorial/02_setup.md#declaring-kedro-mlflow-hooks) in the ``run.py`` (kedro > 0.16.0), ``.kedro.yml`` (kedro >= 0.16.5) or ``pyproject.toml`` (kedro >= 0.16.5) [](https://github.com/Galileo-Galilei/kedro-mlflow/issues/70)
+- `kedro mlflow init` command is no longer declaring hooks in `run.py`. You must now [register your hooks manually](docs/source/03_tutorial/02_setup.md#declaring-kedro-mlflow-hooks) in the ``run.py`` (kedro > 0.16.0), ``.kedro.yml`` (kedro >= 0.16.5) or ``pyproject.toml`` (kedro >= 0.16.5) ([#62](https://github.com/Galileo-Galilei/kedro-mlflow/issues/62))
+- Remove `pipeline_ml` function which was deprecated in 0.3.0. It is now replaced by `pipeline_ml_factory` ([#105](https://github.com/Galileo-Galilei/kedro-mlflow/issues/105))
+- Remove `MlflowDataSet` dataset which was deprecated in 0.3.0. It is now replaced by `MlflowArtifactDataSet` ([#105](https://github.com/Galileo-Galilei/kedro-mlflow/issues/105))
 
 ## [0.3.0] - 2020-10-11
 

--- a/kedro_mlflow/io/__init__.py
+++ b/kedro_mlflow/io/__init__.py
@@ -1,2 +1,2 @@
-from .mlflow_dataset import MlflowArtifactDataSet, MlflowDataSet
+from .mlflow_dataset import MlflowArtifactDataSet
 from .mlflow_metrics_dataset import MlflowMetricsDataSet

--- a/kedro_mlflow/io/mlflow_dataset.py
+++ b/kedro_mlflow/io/mlflow_dataset.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, Union
-from warnings import warn
 
 import mlflow
 from kedro.io import AbstractVersionedDataSet
@@ -90,29 +89,3 @@ class MlflowArtifactDataSet(AbstractVersionedDataSet):
         and consequently does not implements abtracts methods
         """
         pass
-
-
-class MlflowDataSet(MlflowArtifactDataSet):
-    def __new__(
-        cls,
-        data_set: Union[str, Dict],
-        run_id: str = None,
-        artifact_path: str = None,
-        credentials: Dict[str, Any] = None,
-    ):
-        deprecation_msg = (
-            "'MlflowDataSet' is now deprecated and "
-            "has been renamed 'MlflowArtifactDataSet' "
-            "in 'kedro-mlflow>=0.3.0'. "
-            "\nPlease change your 'catalog.yml' entries accordingly, "
-            "since 'MlflowDataSet' will be removed in next release."
-        )
-
-        warn(deprecation_msg, DeprecationWarning, stacklevel=2)
-        super().__new__(
-            cls=cls,
-            data_set=data_set,
-            run_id=run_id,
-            artifact_path=artifact_path,
-            credentials=credentials,
-        )

--- a/kedro_mlflow/pipeline/__init__.py
+++ b/kedro_mlflow/pipeline/__init__.py
@@ -3,4 +3,4 @@ from .pipeline_ml import (
     KedroMlflowPipelineMLInputsError,
     KedroMlflowPipelineMLOutputsError,
 )
-from .pipeline_ml_factory import pipeline_ml, pipeline_ml_factory
+from .pipeline_ml_factory import pipeline_ml_factory

--- a/kedro_mlflow/pipeline/pipeline_ml_factory.py
+++ b/kedro_mlflow/pipeline/pipeline_ml_factory.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
-from warnings import warn
 
 from kedro.pipeline import Pipeline
 from mlflow.models import ModelSignature
@@ -73,24 +72,3 @@ def pipeline_ml_factory(
         model_signature=model_signature,
     )
     return pipeline
-
-
-def pipeline_ml(
-    training: Pipeline,
-    inference: Pipeline,
-    input_name: str = None,
-    conda_env: Optional[Union[str, Path, Dict[str, Any]]] = None,
-    model_name: Optional[str] = "model",
-) -> PipelineML:
-
-    deprecation_msg = (
-        "'pipeline_ml' is now deprecated and "
-        "has been renamed 'pipeline_ml_factory' "
-        "in 'kedro-mlflow>=0.3.0'. "
-        "\nPlease change your 'pipeline.py' or 'hooks.py' entries "
-        "accordingly, since 'pipeline_ml' will be removed in next release."
-    )
-
-    warn(deprecation_msg, DeprecationWarning, stacklevel=2)
-
-    return pipeline_ml_factory(training, inference, input_name, conda_env, model_name)

--- a/tests/io/test_mlflow_dataset.py
+++ b/tests/io/test_mlflow_dataset.py
@@ -8,7 +8,7 @@ from kedro.extras.datasets.pickle import PickleDataSet
 from mlflow.tracking import MlflowClient
 from pytest_lazyfixture import lazy_fixture
 
-from kedro_mlflow.io import MlflowArtifactDataSet, MlflowDataSet
+from kedro_mlflow.io import MlflowArtifactDataSet
 
 
 @pytest.fixture
@@ -159,10 +159,3 @@ def test_is_versioned_dataset_logged_correctly_in_mlflow(tmp_path, tracking_uri,
     assert df1.equals(mlflow_csv_dataset.load())  # and must loadable
 
     mlflow.end_run()
-
-
-def test_raise_deprecation_warning_mlflow_dataset():
-    with pytest.deprecated_call():
-        MlflowDataSet(
-            data_set=dict(type="pandas.CSVDataSet", filepath="fake/path/to/file.csv"),
-        )

--- a/tests/pipeline/test_pipeline_ml.py
+++ b/tests/pipeline/test_pipeline_ml.py
@@ -9,7 +9,6 @@ from kedro_mlflow.pipeline import (
     KedroMlflowPipelineMLDatasetsError,
     KedroMlflowPipelineMLInputsError,
     KedroMlflowPipelineMLOutputsError,
-    pipeline_ml,
     pipeline_ml_factory,
 )
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
@@ -74,23 +73,6 @@ def pipeline_ml_with_tag(pipeline_with_tag):
         input_name="data",
     )
     return pipeline_ml_with_tag
-
-
-def test_raise_deprecation_warning_pipeline_ml(pipeline_with_tag):
-    with pytest.deprecated_call():
-        pipeline_ml(
-            training=pipeline_with_tag,
-            inference=Pipeline(
-                [
-                    node(
-                        func=predict_fun,
-                        inputs=["model", "data"],
-                        outputs="predictions",
-                    )
-                ]
-            ),
-            input_name="data",
-        )
 
 
 @pytest.fixture
@@ -381,7 +363,7 @@ def test_too_many_free_inputs():
     with pytest.raises(
         KedroMlflowPipelineMLInputsError, match="No free input is allowed"
     ):
-        pipeline_ml(
+        pipeline_ml_factory(
             training=Pipeline(
                 [
                     node(


### PR DESCRIPTION
## Description
Close #105 by removing deprecated pipeline_ml and MlflowDataSet

## Development notes

- remove tests, import and definitions of these functions

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
