### PR TITLE
Create KedroMlflowConfig.setup() method and enable configuration to export credentials as environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- It is now possible to supply credentials for the mlflow tracking server within `mlflow.yml` and `credentials.yml`. They will be exported as environment variables during the run. ([#31](https://github.com/Galileo-Galilei/kedro-mlflow/issues/31))
+
 ### Fixed
 
--   Fix `TypeError: unsupported operand type(s) for /: 'str' and 'str'` when using `MlflowArtifactDataSet` with `MlflowModelSaverDataSet` ([#116](https://github.com/Galileo-Galilei/kedro-mlflow/issues/116))
-- Fix various docs typo
+- Fix `TypeError: unsupported operand type(s) for /: 'str' and 'str'` when using `MlflowArtifactDataSet` with `MlflowModelSaverDataSet` ([#116](https://github.com/Galileo-Galilei/kedro-mlflow/issues/116))
+- Fix various docs typo ([#6](https://github.com/Galileo-Galilei/kedro-mlflow/issues/6))
 
 ### Changed
-- Refactor doc structure for readability
+
+- Refactor doc structure for readability ([#6](https://github.com/Galileo-Galilei/kedro-mlflow/issues/6))
+- The `KedroMlflowConfig` no longer creates the mlflow experiment and access to the mlflow tracking server when it is instantiated. A new `setup()` method sets up the mlflow configuration (tracking uri, credentials and experiment management) but must now be called explicitly. ([#97](https://github.com/Galileo-Galilei/kedro-mlflow/issues/97))
 
 ## [0.4.0] - 2020-11-03
 

--- a/docs/source/04_experimentation_tracking/01_configuration.md
+++ b/docs/source/04_experimentation_tracking/01_configuration.md
@@ -31,6 +31,24 @@ mlflow_tracking_uri: mlruns
 
 This is the **only mandatory key in the `mlflow.yml` file**, but there are many others described hereafter that provide fine-grained control on your mlflow setup.
 
+You can also specify some environment variables needed by mlflow (e.g `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) in the credentials and specify them in the `mlflow.yml`. Any key specified will be automatically exported as environment variables.
+
+Your `credentials.yml` will look as follows:
+
+```yaml
+my_mlflow_credentials:
+  AWS_ACCESS_KEY_ID: <your-key>
+  AWS_SECRET_ACCESS_KEY: <your-secret-key>
+```
+
+and your can supply the credentials key of the `mlflow.yml`:
+
+```yaml
+credentials: my_mlflow_credentials
+```
+
+For safety reasons, the credentials will not be accessible within `KedroMlflowConfig` objects. They wil be exported as environment variables *on the fly* when running the pipeline.
+
 ### Configure mlflow experiment
 
 Mlflow enable the user to create "experiments" to organize his work. The different experiments will be visible on the left panel of the mlflow user interface. You can create an experiment through the `mlflow.yml` file witht the `experiment` key:

--- a/kedro_mlflow/framework/hooks/pipeline_hook.py
+++ b/kedro_mlflow/framework/hooks/pipeline_hook.py
@@ -75,7 +75,7 @@ class MlflowPipelineHook:
         )
 
         mlflow_conf = get_mlflow_config(self.context)
-        mlflow.set_tracking_uri(mlflow_conf.mlflow_tracking_uri)
+        mlflow_conf.setup(self.context)
 
         run_name = (
             mlflow_conf.run_opts["name"]
@@ -109,7 +109,10 @@ class MlflowPipelineHook:
 
     @hook_impl
     def after_pipeline_run(
-        self, run_params: Dict[str, Any], pipeline: Pipeline, catalog: DataCatalog,
+        self,
+        run_params: Dict[str, Any],
+        pipeline: Pipeline,
+        catalog: DataCatalog,
     ) -> None:
         """Hook to be invoked after a pipeline runs.
         Args:

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -7,6 +7,17 @@
 # at the root of the project
 mlflow_tracking_uri: mlruns
 
+# All credentials needed for mlflow must be stored in credentials .yml as a dict
+# they will be exported as environment variable
+# If you want to set some credentials,  e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# > in `credentials.yml`:
+# your_mlflow_credentials:
+#   AWS_ACCESS_KEY_ID: 132456
+#   AWS_SECRET_ACCESS_KEY: 132456
+# > in this file `mlflow.yml`:
+# credentials: mlflow_credentials
+
+credentials: null  # must be a valid key in credentials.yml
 
 # EXPERIMENT-RELATED PARAMETERS ----------
 

--- a/tests/framework/context/test_mlflow_context.py
+++ b/tests/framework/context/test_mlflow_context.py
@@ -23,6 +23,7 @@ def test_get_mlflow_config(mocker, tmp_path, config_dir):
         tmp_path / "conf" / "base" / "mlflow.yml",
         dict(
             mlflow_tracking_uri="mlruns",
+            credentials=None,
             experiment=dict(name="fake_package", create=True),
             run=dict(id="123456789", name="my_run", nested=True),
             ui=dict(port="5151", host="localhost"),
@@ -31,6 +32,7 @@ def test_get_mlflow_config(mocker, tmp_path, config_dir):
     )
     expected = {
         "mlflow_tracking_uri": (tmp_path / "mlruns").as_uri(),
+        "credentials": None,
         "experiments": {"name": "fake_package", "create": True},
         "run": {"id": "123456789", "name": "my_run", "nested": True},
         "ui": {"port": "5151", "host": "localhost"},
@@ -48,6 +50,7 @@ def test_mlflow_config_with_templated_config(mocker, tmp_path, config_dir):
         tmp_path / "conf" / "base" / "mlflow.yml",
         dict(
             mlflow_tracking_uri="${mlflow_tracking_uri}",
+            credentials=None,
             experiment=dict(name="fake_package", create=True),
             run=dict(id="123456789", name="my_run", nested=True),
             ui=dict(port="5151", host="localhost"),
@@ -62,6 +65,7 @@ def test_mlflow_config_with_templated_config(mocker, tmp_path, config_dir):
 
     expected = {
         "mlflow_tracking_uri": (tmp_path / "testruns").as_uri(),
+        "credentials": None,
         "experiments": {"name": "fake_package", "create": True},
         "run": {"id": "123456789", "name": "my_run", "nested": True},
         "ui": {"port": "5151", "host": "localhost"},

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -29,6 +29,7 @@ def test_mlflow_yml_rendering(template_mlflowyml):
         mlflow_config = yaml.load(file_handler)
     expected_config = dict(
         mlflow_tracking_uri="mlruns",
+        credentials=None,
         ui=KedroMlflowConfig.UI_OPTS,
         run=KedroMlflowConfig.RUN_OPTS,
         experiment=KedroMlflowConfig.EXPERIMENT_OPTS,


### PR DESCRIPTION
## Description
Fix #31 and #97.

## Development notes

- When instantiating a KedroMlflowConfig object, there is no interaction with mlflow to create the associated experiment. It must be created explicitly
-  A method was added to export mlflow credentials on the fly when running a pipeline.

```yaml
# credentials.yml
my_credentials: 
  AWS_SECRET_KEY: <key>
```

```yaml
# mlflow.yml
credentials: my_credentials
```

- interactively, you must now call the setup method to setus the configuration up:

```python
# exploratory.py
from kedro.context import load_context
from kedro_mlflow.context import get_mlflow_config

context=load_context(".")
mlflow_config=get_mlflow_config(context)
mlflow_config.setup(context)
```

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
