### PR TITLE
PARTIAL #6 - Fix documentation links in bumpversion configuration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,10 +9,10 @@ current_version = 0.4.0
 
 [bumpversion:file:docs/source/01_introduction/02_motivation.md]
 
-[bumpversion:file:docs/source/01_introduction/03_installation.md]
+[bumpversion:file:docs/source/02_installation/01_installation.md]
 
-[bumpversion:file:docs/source/02_hello_world_example/01_example_project.md]
+[bumpversion:file:docs/source/03_getting_started/01_example_project.md]
 
-[bumpversion:file:docs/source/03_tutorial/04_version_parameters.md]
+[bumpversion:file:docs/source/04_experimentation_tracking/02_version_parameters.md]
 
-[bumpversion:file:docs/source/03_tutorial/05_version_datasets.md]
+[bumpversion:file:docs/source/04_experimentation_tracking/03_version_datasets.md]


### PR DESCRIPTION
## Description
Fix wrong documentation reference in `bumpversion.cfg` which prevents the release candidate to be created.

## Development notes
Change link references in `bumpversion.cfg`

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
