### PR TITLE
Fix/workflow security

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,19 +36,23 @@ jobs:
       uses: thomaseizinger/keep-a-changelog-new-release@v1
       with:
         version: ${{ steps.bump_version.outputs.package_version }}
-    - name: Commit changes to a release-candidate branch
+    - name: Create a new release branch
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git checkout -b release-candidate-${{ steps.bump_version.outputs.package_version }}
-        git commit -am "Release ${{ steps.bump_version.outputs.package_version }} - Bump version and CHANGELOG"
-        git push -u origin release-candidate-${{ steps.bump_version.outputs.package_version }}
-    - name: Open a PR to merge the release candidate to master
+        git checkout -b release-${{ steps.bump_version.outputs.package_version }}
+        git push -u origin release-${{ steps.bump_version.outputs.package_version }}
+    - name: Open a PR to merge the release to master
+      id: open_pr
       uses: vsoch/pull-request-action@1.0.12
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULL_REQUEST_BRANCH: master
-        PULL_REQUEST_FROM_BRANCH: release-candidate-${{ steps.bump_version.outputs.package_version }}
-        PULL_REQUEST_TITLE: "Release candidate ${{ steps.bump_version.outputs.package_version }}"
+        PULL_REQUEST_FROM_BRANCH: release-${{ steps.bump_version.outputs.package_version }}
+        PULL_REQUEST_TITLE: "Release ${{ steps.bump_version.outputs.package_version }}"
         PULL_REQUEST_BODY: "Bump version and CHANGELOG for next release."
-        # PULL_REQUEST_ASSIGNEES: "${{ github.repository_owner }}"  # currently buggued in the action
+        PULL_REQUEST_ASSIGNEES: "${{ github.repository_owner }}"
+    - name: Commit the changes
+      run: |
+        git commit -am "FIX #${{ steps.open_pr.outputs.pull_request_number }}  - Bump version and CHANGELOG for release ${{ steps.bump_version.outputs.package_version }}"
+        git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,21 +32,22 @@ jobs:
         git checkout -b develop --track origin/develop
         git merge master
         git push
-    - name: Set dynamically package version as environment variable
+    - name: Set dynamically package version as output variable # see https://github.com/actions/create-release/issues/39
       # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+      id: set_package_version
       run: |
-        echo "::set-env name=PACKAGE_VERSION::$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')"
+        echo "::set-output name=PACKAGE_VERSION::$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')"
     - name: Create temporary file with the body content for the release
       run: |
-        grep -Poz "## \[${{env.PACKAGE_VERSION}}] - \d{4}-\d{2}-\d{2}[\S\s]+?(?=## \[\d+\.\d+\.\d+\]|\[.+\]:)" CHANGELOG.md > release_body.md
+        grep -Poz "## \[${{steps.set_package_version.outputs.PACKAGE_VERSION}}] - \d{4}-\d{2}-\d{2}[\S\s]+?(?=## \[\d+\.\d+\.\d+\]|\[.+\]:)" CHANGELOG.md > release_body.md
     - name: Create Release # https://github.com/actions/create-release
       id: create_release
       uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: ${{ env.PACKAGE_VERSION }}
-        release_name: Release ${{ env.PACKAGE_VERSION }}
+        tag_name: ${{ steps.set_package_version.outputs.PACKAGE_VERSION }}
+        release_name: Release ${{ steps.set_package_version.outputs.PACKAGE_VERSION }}
         body_path: ./release_body.md
         draft: false
         prerelease: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}  # token is not mandatory but make access more stable
         file: ./coverage.xml
         env_vars: OS,PYTHON
         fail_ci_if_error: true

--- a/requirements/docs_requirements.txt
+++ b/requirements/docs_requirements.txt
@@ -2,3 +2,5 @@ sphinx==3.1.2
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
 sphinx-markdown-tables==0.0.15
+pandas>=1.0.0, <1.2.0 # avoid to make readthedocs load rc version
+numpy>=1.0.0, <1.19.0 # bug on windows


### PR DESCRIPTION
## Description
Fix some known workflow security flaws due to github action set-env, see [github blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

## Development notes
- Replace set-env entries by set-output when necessary
- Add the PR number created when creating the release branch to the commit message.
- Fix codecov upload by adding a token
- Fix readthedocs build failing by pinning pandas and numpy

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
