### PR TITLE
FIX #57 - Change default branch from develop to master and simplify publishing workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,11 @@ assignees: ''
 ---
 
 ## Description
+
 Short description of the problem here.
 
 ## Context
+
 How has this bug affected you? What were you trying to accomplish?
 
 ## Steps to Reproduce
@@ -22,9 +24,11 @@ Please provide a detailed description. A Minimal Reproducible Example would real
 3. [And so on...]
 
 ## Expected Result
+
 Tell us what should happen.
 
 ## Actual Result
+
 Tell us what happens instead.
 
 ```
@@ -36,19 +40,21 @@ Tell us what happens instead.
 ```
 
 ## Your Environment
+
 Include as many relevant details about the environment in which you experienced the bug:
 
 * `kedro` and `kedro-mlflow` version used (`pip show kedro` and `pip show kedro-mlflow`):
 * Python version used (`python -V`):
 * Operating system and version:
 
-## Does the bug also happen with the last version on develop?
+## Does the bug also happen with the last version on master?
 
-The plugin is still in early development and known bugs are fixed as soon as we can. If you are lucky, your bug is already fixed on the `develop` branch which is the most up to date. This branch contains our more recent development unpublished on PyPI yet.
+The plugin is still in early development and known bugs are fixed as soon as we can. If you are lucky, your bug is already fixed on the `master` branch which is the most up to date. This branch contains our more recent development unpublished on PyPI yet.
 
 In your environment, please try:
 
 ```bash
-pip install --upgrade git+https://github.com/Galileo-Galilei/kedro-mlflow@develop
+pip install --upgrade git+https://github.com/Galileo-Galilei/kedro-mlflow
 ```
-And check if you can to reproduce the error. If you can't, just wait for the next release or use the develop branch at your own risk!
+
+And check if you can to reproduce the error. If you can't, just wait for the next release or use the master branch at your own risk!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,10 @@ What have you changed, and how has this been tested?
 
 ## Checklist
 
-- [ ] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
+- [ ] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
 - [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
 - [ ] Update the documentation to reflect the code changes
-- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
+- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
 - [ ] Add tests to cover your changes
 
 ## Notice

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,6 @@ jobs:
     - name: Build package dist from source # A better way will be : https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ but pep 517 is still marked as experimental
       run: |
         python setup.py sdist
-    - name:  Merge back to develop  # we have to set the config first on a fresh machine
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git checkout -b develop --track origin/develop
-        git merge master
-        git push
     - name: Set dynamically package version as output variable # see https://github.com/actions/create-release/issues/39
       # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       id: set_package_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: test
 
 on:
   push:
-    branches: [develop, master]
+    branches: [master]
   pull_request:
-    branches: [develop, master]
+    branches: [master]
 
 jobs:
   lint_and_test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The current workflow is the following:
 2. Fork the repo
 3. Develop locally:
     - Install the precommit file (`pip install pre-commit`, then `pre-commit install`)
-    - Create a branch based on the develop branch (``git checkout -b <prefix-branchname> develop``)
+    - Create a branch based on the master branch (``git checkout -b <prefix-branchname> master``)
     - Create a conda environment (conda create -n <your-env-name> python==3.7)
     - Activate this environment (`conda activate <your-env-name>`)
     - Install the extra dependencies for tests (`pip install kedro-mlflow[tests]`)
@@ -17,8 +17,8 @@ The current workflow is the following:
     - Update documentation accordingly
     - Update `CHANGELOG.md` according to ["Keep a Changelog" guidelines](https://keepachangelog.com/en/1.0.0/)
     - Squash all the changes within a single commit as much as possible, and ensure the commit message has the format "FIX ``#<issue-number>`` - Informative description"
-    - Rebase your branch on ``develop`` to ensure linear history
-    - Open a pull request against ``develop``
+    - Rebase your branch on ``master`` to ensure linear history
+    - Open a pull request against ``master``
 5. Ask for review:
     - Assign randomly the review to two of the contributors (one review will be enough most of the time, but reviewers may not be available).
     - Wait for review
@@ -44,5 +44,5 @@ The current workflow is the following:
     - Merge the PR to master
 4. Checkout the [publish workflow](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Apublish) to see if:
     - The package has been uploaded on PyPI sucessfully
-    - The changes have been merged back to develop
-5. If the pipeline has failed, please raise an issue to correct the CI, and ensure merge on develop manually.
+    - A Github release has been created
+5. If the pipeline has failed, please raise an issue to correct the CI, and ensure merge on master manually.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 ----------------------------------------------------------
 | Branch | Tests | Coverage | Documentation | Deployment | Activity |
 |--------|-------|----------|---------------|------------|------------|
-| `develop`| [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=develop)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Adevelop)| [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/develop/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/develop)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=latest)](https://kedro-mlflow.readthedocs.io/en/latest/)| [![create-release-candidate](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/create-release-candidate/badge.svg?branch=develop)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Adevelop+workflow%3Acreate-release-candidate)|[![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.6.0)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.6.0...develop)|
-| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/)|[![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish)||
+| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/)|[![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish)|[![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.6.0)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.6.0...master)|
 
 # What is kedro-mlflow?
 
@@ -33,10 +32,10 @@
 pip install kedro-mlflow
 ```
 
-If you want to use the ``develop`` version of the package which is the most up to date, you can install the package from github:
+If you want to use the most up to date version of the package which is under development and not released yet, you can install the package from github:
 
 ```console
-pip install --upgrade git+https://github.com/Galileo-Galilei/kedro-mlflow.git@develop
+pip install --upgrade git+https://github.com/Galileo-Galilei/kedro-mlflow.git
 ```
 
 I strongly recommend to use ``conda`` (a package manager) to create an environment and to read [``kedro`` installation guide](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html).
@@ -58,7 +57,7 @@ Some frequently asked questions on more advanced features:
 
 # Release and roadmap
 
-The [release history](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) centralizes packages improvements across time. The main features coming in next releases are [listed on github milestones](https://github.com/Galileo-Galilei/kedro-mlflow/milestones). Feel free to upvote/downvote and discuss prioritization in associated issues.
+The [release history](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) centralizes packages improvements across time. The main features coming in next releases are [listed on github milestones](https://github.com/Galileo-Galilei/kedro-mlflow/milestones). Feel free to upvote/downvote and discuss prioritization in associated issues.
 
 # Disclaimer
 
@@ -70,7 +69,7 @@ If you want to see how to migrate from one version of `kedro-mlflow` to another,
 
 # Can I contribute?
 
-We'd be happy to receive help to maintain and improve the package. Any PR will be considered (from typo in the docs to core features add-on) Please check the [contributing guidelines](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md).
+We'd be happy to receive help to maintain and improve the package. Any PR will be considered (from typo in the docs to core features add-on) Please check the [contributing guidelines](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md).
 
 # Main contributors
 

--- a/docs/source/02_installation/01_installation.md
+++ b/docs/source/02_installation/01_installation.md
@@ -54,10 +54,10 @@ pip install --upgrade kedro-mlflow
 
 ### Install from sources
 
-You may want to install the develop branch which has unreleased features:
+You may want to install the master branch which has unreleased features:
 
 ```console
-pip install git+https://github.com/Galileo-Galilei/kedro-mlflow.git@develop
+pip install git+https://github.com/Galileo-Galilei/kedro-mlflow.git
 ```
 
 ## Check the installation


### PR DESCRIPTION
## Description
The current workflow is unecessarily complex, having a single branch as source of truth will make deployment easier.

## Development notes

- Switch default branch from develop to master
- Update documentation accordingly
- Remove develop branch

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CONTRIBUTING.md) guidelines
- N/A Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- N/A Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/develop/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- N/A Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
