### PR TITLE
FIX #144 - Make kedro-mlflow fully compatible with kedro>=0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+-   `kedro-mlflow` now supports `kedro>=0.17.1` ([#144](https://github.com/Galileo-Galilei/kedro-mlflow/issues/144)).
+### Changed
+
+-   Drop support for `kedro==0.17.0`, since the kedro core team [made a breaking change in `0.17.1`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md#breaking-changes-to-the-api). All future plugin updates will be only compatible with `kedro>=0.17.1`.
+
 ## [0.6.0] - 2021-03-14
 
 ### Added

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import click
 from kedro.framework.cli.utils import _add_src_to_path
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import _get_project_metadata, _is_project
 
@@ -80,6 +81,7 @@ def init(env, force, silent):
     project_path = Path().cwd()
     project_metadata = _get_project_metadata(project_path)
     _add_src_to_path(project_metadata.source_dir, project_path)
+    configure_project(project_metadata.package_name)
     session = KedroSession.create(
         project_metadata.package_name, project_path=project_path
     )
@@ -136,6 +138,7 @@ def ui(env):
     project_path = Path().cwd()
     project_metadata = _get_project_metadata(project_path)
     _add_src_to_path(project_metadata.source_dir, project_path)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=project_path,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mlflow>=1.0.0, <2.0.0
-kedro==0.17.0  # seems to be broken with kedro==0.17.1
+kedro>=0.17.1,<0.18.0  # seems to be broken with kedro==0.17.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from cookiecutter.main import cookiecutter
 from kedro import __version__ as kedro_version
 from kedro.framework.cli.cli import TEMPLATE_PATH
+from kedro.framework.hooks.manager import get_hook_manager
+from kedro.framework.session.session import _deactivate_session
 
 from kedro_mlflow.framework.cli.cli import TEMPLATE_FOLDER_PATH
 from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
@@ -16,6 +18,22 @@ def cleanup_mlflow_after_runs():
     yield
     while mlflow.active_run():
         mlflow.end_run()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_kedro_session():
+    # A test function will be run at this point
+    yield
+    _deactivate_session()
+
+
+@pytest.fixture(autouse=True)
+def clear_hook_manager():
+    yield
+    hook_manager = get_hook_manager()
+    plugins = hook_manager.get_plugins()
+    for plugin in plugins:
+        hook_manager.unregister(plugin)
 
 
 @pytest.fixture
@@ -45,12 +63,86 @@ def kedro_project(tmp_path):
 
 
 @pytest.fixture
-def kedro_project_with_mlflow_conf(tmp_path, kedro_project):
+def kedro_project_with_mlflow_conf(kedro_project):
     write_jinja_template(
         src=TEMPLATE_FOLDER_PATH / "mlflow.yml",
         is_cookiecutter=False,
-        dst=tmp_path / "fake-project" / "conf" / "local" / "mlflow.yml",
+        dst=kedro_project / "conf" / "local" / "mlflow.yml",
         python_package="fake_project",
     )
 
-    return tmp_path / "fake-project"
+    return kedro_project
+
+
+@pytest.fixture
+def kedro_project_with_tcl(tmp_path):
+    # TODO: find a better way to inject dynamically
+    # the templated config loader without modifying the template
+
+    config = {
+        "output_dir": tmp_path,
+        "kedro_version": kedro_version,
+        "project_name": "A kedro project with a templated config loader",
+        "repo_name": "kedro-project-with-tcl",
+        "python_package": "kedro_project_with_tcl",
+        "include_example": True,
+    }
+
+    cookiecutter(
+        str(TEMPLATE_PATH),
+        output_dir=config["output_dir"],
+        no_input=True,
+        extra_context=config,
+    )
+
+    shutil.rmtree(
+        tmp_path / config["repo_name"] / "src" / "tests"
+    )  # avoid conflicts with pytest
+
+    hooks_py = """
+from typing import Any, Dict, Iterable, Optional
+
+from kedro.config import TemplatedConfigLoader
+from kedro.framework.hooks import hook_impl
+from kedro.io import DataCatalog
+from kedro.pipeline import Pipeline
+from kedro.versioning import Journal
+
+
+class ProjectHooks:
+    @hook_impl
+    def register_pipelines(self) -> Dict[str, Pipeline]:
+        return {"__default__": Pipeline([])}
+
+    @hook_impl
+    def register_config_loader(self, conf_paths: Iterable[str]) -> TemplatedConfigLoader:
+        return TemplatedConfigLoader(
+            conf_paths,
+            globals_pattern="*globals.yml",
+            globals_dict={}
+        )
+
+    @hook_impl
+    def register_catalog(
+        self,
+        catalog: Optional[Dict[str, Dict[str, Any]]],
+        credentials: Dict[str, Dict[str, Any]],
+        load_versions: Dict[str, str],
+        save_version: str,
+        journal: Journal,
+    ) -> DataCatalog:
+        return DataCatalog.from_config(
+            catalog, credentials, load_versions, save_version, journal
+        )
+"""
+
+    def _write_py(filepath, txt):
+        filepath.write_text(txt)
+
+    kedro_project_with_tcl = tmp_path / config["repo_name"]
+
+    _write_py(
+        kedro_project_with_tcl / "src" / config["python_package"] / "hooks.py", hooks_py
+    )
+
+    return kedro_project_with_tcl

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -5,7 +5,10 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from kedro.framework.cli.cli import info
+from kedro.framework.cli.utils import _add_src_to_path
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
+from kedro.framework.startup import _get_project_metadata
 
 from kedro_mlflow.framework.cli.cli import init as cli_init
 from kedro_mlflow.framework.cli.cli import mlflow_commands as cli_mlflow
@@ -72,6 +75,9 @@ def test_cli_init_existing_config(monkeypatch, kedro_project_with_mlflow_conf):
     # "kedro_project" is a pytest.fixture declared in conftest
     cli_runner = CliRunner()
     monkeypatch.chdir(kedro_project_with_mlflow_conf)
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ) as session:
@@ -96,6 +102,9 @@ def test_cli_init_existing_config_force_option(monkeypatch, kedro_project):
     monkeypatch.chdir(kedro_project)
     cli_runner = CliRunner()
 
+    project_metadata = _get_project_metadata(kedro_project)
+    _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create("fake_project", project_path=kedro_project) as session:
         context = session.load_context()
 

--- a/tests/framework/context/test_config.py
+++ b/tests/framework/context/test_config.py
@@ -3,7 +3,10 @@ import os
 import mlflow
 import pytest
 import yaml
+from kedro.framework.cli.utils import _add_src_to_path
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
+from kedro.framework.startup import _get_project_metadata
 from mlflow.tracking import MlflowClient
 
 from kedro_mlflow.framework.context.config import (
@@ -86,6 +89,9 @@ def test_kedro_mlflow_config_new_experiment_does_not_exists(
         experiment_opts=dict(name="exp1"),
     )
 
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):
@@ -106,6 +112,10 @@ def test_kedro_mlflow_config_experiment_exists(mocker, kedro_project_with_mlflow
         mlflow_tracking_uri="mlruns",
         experiment_opts=dict(name="exp1"),
     )
+
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):
@@ -129,6 +139,10 @@ def test_kedro_mlflow_config_experiment_was_deleted(kedro_project_with_mlflow_co
         mlflow_tracking_uri="mlruns",
         experiment_opts=dict(name="exp1"),
     )
+
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):
@@ -148,6 +162,10 @@ def test_kedro_mlflow_config_setup_set_tracking_uri(kedro_project_with_mlflow_co
         mlflow_tracking_uri="awesome_tracking",
         experiment_opts=dict(name="exp1"),
     )
+
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):
@@ -166,6 +184,10 @@ def test_kedro_mlflow_config_setup_export_credentials(kedro_project_with_mlflow_
     config = KedroMlflowConfig(
         project_path=kedro_project_with_mlflow_conf, credentials="my_mlflow_creds"
     )
+
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):
@@ -193,6 +215,10 @@ def test_kedro_mlflow_config_setup_tracking_priority(kedro_project_with_mlflow_c
         mlflow_tracking_uri="mlruns1",
         credentials="my_mlflow_creds",
     )
+
+    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         "fake_project", project_path=kedro_project_with_mlflow_conf
     ):

--- a/tests/framework/context/test_mlflow_context.py
+++ b/tests/framework/context/test_mlflow_context.py
@@ -1,5 +1,7 @@
 import pytest
 import yaml
+from kedro.framework.cli.utils import _add_src_to_path
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import _get_project_metadata
 
@@ -8,7 +10,6 @@ from kedro_mlflow.framework.context.config import KedroMlflowConfigError
 
 
 def _write_yaml(filepath, config):
-    filepath.parent.mkdir(parents=True, exist_ok=True)
     yaml_str = yaml.dump(config)
     filepath.write_text(yaml_str)
 
@@ -16,86 +17,6 @@ def _write_yaml(filepath, config):
 # TODO : reenable this test which is currently failing beacause kedro "import settings"
 # is completetly messing up because we have several projects
 # and the first import wins
-
-# import shutil
-# from cookiecutter.main import cookiecutter
-# from kedro import __version__ as kedro_version
-# from kedro.framework.cli.cli import TEMPLATE_PATH
-# from kedro.framework.cli.utils import _add_src_to_path
-
-# @pytest.fixture
-# def kedro_project_with_tcl(tmp_path):
-#     # TODO: find a better way to inject dynamically
-#     # the templated config loader without modifying the template
-
-#     config = {
-#         "output_dir": tmp_path,
-#         "kedro_version": kedro_version,
-#         "project_name": "This is a kedro project with a TemplatedConfigLoader",
-#         "repo_name": "kedro-project-tcl",
-#         "python_package": "kedro_project_tcl",
-#         "include_example": True,
-#     }
-
-#     cookiecutter(
-#         str(TEMPLATE_PATH),
-#         output_dir=config["output_dir"],
-#         no_input=True,
-#         extra_context=config,
-#     )
-
-#     shutil.rmtree(
-#         tmp_path / "kedro-project-tcl" / "src" / "tests"
-#     )  # avoid conflicts with pytest
-
-#     kedro_project_with_tcl = tmp_path / "kedro-project-tcl"
-#     hooks_py = """
-# from typing import Any, Dict, Iterable, Optional
-
-# from kedro.config import TemplatedConfigLoader
-# from kedro.framework.hooks import hook_impl
-# from kedro.io import DataCatalog
-# from kedro.pipeline import Pipeline
-# from kedro.versioning import Journal
-
-
-# class ProjectHooks:
-#     @hook_impl
-#     def register_pipelines(self) -> Dict[str, Pipeline]:
-#         return {"__default__": Pipeline([])}
-
-#     @hook_impl
-#     def register_config_loader(self, conf_paths: Iterable[str]) -> TemplatedConfigLoader:
-#         return TemplatedConfigLoader(
-#             conf_paths,
-#             globals_pattern="*globals.yml",
-#             globals_dict={}
-#         )
-
-#     @hook_impl
-#     def register_catalog(
-#         self,
-#         catalog: Optional[Dict[str, Dict[str, Any]]],
-#         credentials: Dict[str, Dict[str, Any]],
-#         load_versions: Dict[str, str],
-#         save_version: str,
-#         journal: Journal,
-#     ) -> DataCatalog:
-#         return DataCatalog.from_config(
-#             catalog, credentials, load_versions, save_version, journal
-#         )
-# """
-
-#     def _write_py(filepath, txt):
-#         filepath.parent.mkdir(parents=True, exist_ok=True)
-#         filepath.write_text(txt)
-
-#     metadata = _get_project_metadata(kedro_project_with_tcl)
-#     _write_py(
-#         kedro_project_with_tcl / "src" / metadata.package_name / "hooks.py", hooks_py
-#     )
-
-#     return kedro_project_with_tcl
 
 
 def test_get_mlflow_config(kedro_project):
@@ -135,68 +56,75 @@ def test_get_mlflow_config(kedro_project):
         },
     }
 
-    with KedroSession.create("fake_project", project_path=kedro_project):
+    project_metadata = _get_project_metadata(kedro_project)
+    _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
+    with KedroSession.create(project_metadata.package_name, project_path=kedro_project):
         assert get_mlflow_config().to_dict() == expected
 
 
 def test_get_mlflow_config_in_uninitialized_project(kedro_project):
     # config_with_base_mlflow_conf is a pytest.fixture in conftest
-    metadata = _get_project_metadata(kedro_project)
     with pytest.raises(
         KedroMlflowConfigError, match="No 'mlflow.yml' config file found in environment"
     ):
-        with KedroSession.create(metadata.package_name, kedro_project):
+        project_metadata = _get_project_metadata(kedro_project)
+        _add_src_to_path(project_metadata.source_dir, kedro_project)
+        configure_project(project_metadata.package_name)
+        with KedroSession.create(project_metadata.package_name, kedro_project):
             get_mlflow_config()
 
 
 # TODO : reenable this test which is currently failing beacause kedro "import settings"
-# is completetly messing up beacuase we have several projects
-# and the first imort wins
+# is completetly messing up beacause we have several projects
+# and the first import wins
 
-# def test_mlflow_config_with_templated_config_loader(
-#     kedro_project_with_tcl,
-# ):
 
-#     _write_yaml(
-#         kedro_project_with_tcl / "conf" / "local" / "mlflow.yml",
-#         dict(
-#             mlflow_tracking_uri="${mlflow_tracking_uri}",
-#             credentials=None,
-#             experiment=dict(name="fake_package", create=True),
-#             run=dict(id="123456789", name="my_run", nested=True),
-#             ui=dict(port="5151", host="localhost"),
-#             hooks=dict(
-#                 node=dict(
-#                     flatten_dict_params=True,
-#                     recursive=False,
-#                     sep="-",
-#                     long_parameters_strategy="truncate",
-#                 )
-#             ),
-#         ),
-#     )
+def test_mlflow_config_with_templated_config_loader(
+    kedro_project_with_tcl,
+):
 
-#     _write_yaml(
-#         kedro_project_with_tcl / "conf" / "local" / "globals.yml",
-#         dict(mlflow_tracking_uri="dynamic_mlruns"),
-#     )
+    _write_yaml(
+        kedro_project_with_tcl / "conf" / "local" / "mlflow.yml",
+        dict(
+            mlflow_tracking_uri="${mlflow_tracking_uri}",
+            credentials=None,
+            experiment=dict(name="fake_package", create=True),
+            run=dict(id="123456789", name="my_run", nested=True),
+            ui=dict(port="5151", host="localhost"),
+            hooks=dict(
+                node=dict(
+                    flatten_dict_params=True,
+                    recursive=False,
+                    sep="-",
+                    long_parameters_strategy="truncate",
+                )
+            ),
+        ),
+    )
 
-#     expected = {
-#         "mlflow_tracking_uri": (kedro_project_with_tcl / "dynamic_mlruns").as_uri(),
-#         "credentials": None,
-#         "experiments": {"name": "fake_package", "create": True},
-#         "run": {"id": "123456789", "name": "my_run", "nested": True},
-#         "ui": {"port": "5151", "host": "localhost"},
-#         "hooks": {
-#             "node": {
-#                 "flatten_dict_params": True,
-#                 "recursive": False,
-#                 "sep": "-",
-#                 "long_parameters_strategy": "truncate",
-#             }
-#         },
-#     }
-#     metadata = _get_project_metadata(kedro_project_with_tcl)
-#     _add_src_to_path(metadata.source_dir, kedro_project_with_tcl)
-#     with KedroSession.create(metadata.package_name, kedro_project_with_tcl):
-#         assert get_mlflow_config().to_dict() == expected
+    _write_yaml(
+        kedro_project_with_tcl / "conf" / "local" / "globals.yml",
+        dict(mlflow_tracking_uri="dynamic_mlruns"),
+    )
+
+    expected = {
+        "mlflow_tracking_uri": (kedro_project_with_tcl / "dynamic_mlruns").as_uri(),
+        "credentials": None,
+        "experiments": {"name": "fake_package", "create": True},
+        "run": {"id": "123456789", "name": "my_run", "nested": True},
+        "ui": {"port": "5151", "host": "localhost"},
+        "hooks": {
+            "node": {
+                "flatten_dict_params": True,
+                "recursive": False,
+                "sep": "-",
+                "long_parameters_strategy": "truncate",
+            }
+        },
+    }
+    project_metadata = _get_project_metadata(kedro_project_with_tcl)
+    _add_src_to_path(project_metadata.source_dir, kedro_project_with_tcl)
+    configure_project(project_metadata.package_name)
+    with KedroSession.create(project_metadata.package_name, kedro_project_with_tcl):
+        assert get_mlflow_config().to_dict() == expected

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -5,6 +5,7 @@ import mlflow
 import pytest
 import yaml
 from kedro.framework.cli.utils import _add_src_to_path
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import _get_project_metadata
 from kedro.io import DataCatalog, MemoryDataSet
@@ -123,6 +124,7 @@ def test_pipeline_run_hook_getting_configs(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,
@@ -187,6 +189,7 @@ def test_node_hook_logging(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,
@@ -237,6 +240,7 @@ def test_node_hook_logging_below_limit_all_strategy(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,
@@ -286,6 +290,7 @@ def test_node_hook_logging_above_limit_truncate_strategy(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,
@@ -337,6 +342,7 @@ def test_node_hook_logging_above_limit_fail_strategy(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,
@@ -392,6 +398,7 @@ def test_node_hook_logging_above_limit_tag_strategy(
 
     project_metadata = _get_project_metadata(kedro_project)
     _add_src_to_path(project_metadata.source_dir, kedro_project)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project,

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -7,6 +7,7 @@ import yaml
 from kedro.extras.datasets.pickle import PickleDataSet
 from kedro.framework.cli.utils import _add_src_to_path
 from kedro.framework.context import KedroContext
+from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import _get_project_metadata
 from kedro.io import DataCatalog, MemoryDataSet
@@ -299,6 +300,7 @@ def test_mlflow_pipeline_hook_with_different_pipeline_types(
 
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,
@@ -376,6 +378,7 @@ def test_mlflow_pipeline_hook_with_copy_mode(
     # config_with_base_mlflow_conf is a conftest fixture
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,
@@ -432,6 +435,7 @@ def test_mlflow_pipeline_hook_metrics_with_run_id(
 
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,
@@ -518,6 +522,7 @@ def test_mlflow_pipeline_hook_save_pipeline_ml_with_parameters(
     # config_with_base_mlflow_conf is a conftest fixture
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,
@@ -603,6 +608,7 @@ def test_mlflow_pipeline_hook_with_pipeline_ml_signature(
     # config_with_base_mlflow_conf is a conftest fixture
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,
@@ -690,6 +696,7 @@ def test_on_pipeline_error(kedro_project_with_mlflow_conf):
 
     project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
     _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
+    configure_project(project_metadata.package_name)
     with KedroSession.create(
         package_name=project_metadata.package_name,
         project_path=kedro_project_with_mlflow_conf,


### PR DESCRIPTION
## Description
Continue fixing #144 because current PyPI version does not work with kedro>=0.17.1

## Development notes

- Update all tests
- Update CLI to call ``configure_project`` command

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- N/A Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
