### PR TITLE
Add possibility to deactivate mlflow tracking for given pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+-   It is now possible to deactivate tracking (for parameters and datasets) by specifying a key `disabled_tracking: pipelines: [<pipeline-name>]` in the `mlflow.yml` configuration file. ([#92](https://github.com/Galileo-Galilei/kedro-mlflow/issues/92))
+
 ## [0.7.0] - 2021-03-17
 
 ### Added

--- a/docs/source/04_experimentation_tracking/01_configuration.md
+++ b/docs/source/04_experimentation_tracking/01_configuration.md
@@ -49,6 +49,20 @@ credentials: my_mlflow_credentials
 
 For safety reasons, the credentials will not be accessible within `KedroMlflowConfig` objects. They wil be exported as environment variables *on the fly* when running the pipeline.
 
+### Deactivate tracking under conditions
+
+`kedro-mlflow` logs every run parameters in mlflow. You may want to avoid tracking some runs (for instance while debugging to avoid polluting your mlflow database, or because some pipelines are not ml related and it does not makes sense to log their parameters).
+
+You can specify the name of the pipelines you want to turn off:
+
+```yaml
+disable_tracking:
+  pipelines:
+    - <pipeline-name>
+```
+
+Notice that it will stop autologging parameters but also any `Mlflow<Artifact/Metrics/ModelLogger>Dataset` you may have in these deactivated pipelines.
+
 ### Configure mlflow experiment
 
 Mlflow enable the user to create "experiments" to organize his work. The different experiments will be visible on the left panel of the mlflow user interface. You can create an experiment through the `mlflow.yml` file witht the `experiment` key:

--- a/kedro_mlflow/framework/cli/cli_utils.py
+++ b/kedro_mlflow/framework/cli/cli_utils.py
@@ -20,7 +20,7 @@ def render_jinja_template(
 
     template_loader = FileSystemLoader(searchpath=src.parent.as_posix())
     # the keep_trailing_new_line option is mandatory to
-    # make sure that black formatting wil be preserved
+    # make sure that black formatting will be preserved
     template_env = Environment(loader=template_loader, keep_trailing_newline=True)
     template = template_env.get_template(src.name)
     if is_cookiecutter:

--- a/kedro_mlflow/framework/hooks/pipeline_hook.py
+++ b/kedro_mlflow/framework/hooks/pipeline_hook.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -13,6 +14,8 @@ from mlflow.entities import RunStatus
 from mlflow.models import infer_signature
 
 from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.framework.hooks.utils import _assert_mlflow_enabled
+from kedro_mlflow.io.catalog.switch_catalog_logging import switch_catalog_logging
 from kedro_mlflow.io.metrics import MlflowMetricsDataSet
 from kedro_mlflow.mlflow import KedroPipelineModel
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
@@ -21,7 +24,7 @@ from kedro_mlflow.utils import _parse_requirements
 
 class MlflowPipelineHook:
     def __init__(self):
-        self.context = None
+        self._is_mlflow_enabled = True
 
     @hook_impl
     def after_catalog_created(
@@ -34,6 +37,7 @@ class MlflowPipelineHook:
         load_versions: str,
         run_id: str,
     ):
+
         for name, dataset in catalog._data_sets.items():
             if isinstance(dataset, MlflowMetricsDataSet) and dataset._prefix is None:
                 if dataset._run_id is not None:
@@ -69,38 +73,46 @@ class MlflowPipelineHook:
             pipeline: The ``Pipeline`` that will be run.
             catalog: The ``DataCatalog`` to be used during the run.
         """
-        mlflow_conf = get_mlflow_config()
-        mlflow_conf.setup()
+        self._is_mlflow_enabled = _assert_mlflow_enabled(run_params["pipeline_name"])
 
-        run_name = (
-            mlflow_conf.run_opts["name"]
-            if mlflow_conf.run_opts["name"] is not None
-            else run_params["pipeline_name"]
-        )
-        mlflow.start_run(
-            run_id=mlflow_conf.run_opts["id"],
-            experiment_id=mlflow_conf.experiment.experiment_id,
-            run_name=run_name,
-            nested=mlflow_conf.run_opts["nested"],
-        )
-        # Set tags only for run parameters that have values.
-        mlflow.set_tags({k: v for k, v in run_params.items() if v})
-        # add manually git sha for consistency with the journal
-        # TODO : this does not take into account not committed files, so it
-        # does not ensure reproducibility. Define what to do.
-        mlflow.set_tag("git_sha", _git_sha(run_params["project_path"]))
-        mlflow.set_tag(
-            "kedro_command",
-            _generate_kedro_command(
-                tags=run_params["tags"],
-                node_names=run_params["node_names"],
-                from_nodes=run_params["from_nodes"],
-                to_nodes=run_params["to_nodes"],
-                from_inputs=run_params["from_inputs"],
-                load_versions=run_params["load_versions"],
-                pipeline_name=run_params["pipeline_name"],
-            ),
-        )
+        if self._is_mlflow_enabled:
+            mlflow_conf = get_mlflow_config()
+            mlflow_conf.setup()
+
+            run_name = (
+                mlflow_conf.run_opts["name"]
+                if mlflow_conf.run_opts["name"] is not None
+                else run_params["pipeline_name"]
+            )
+            mlflow.start_run(
+                run_id=mlflow_conf.run_opts["id"],
+                experiment_id=mlflow_conf.experiment.experiment_id,
+                run_name=run_name,
+                nested=mlflow_conf.run_opts["nested"],
+            )
+            # Set tags only for run parameters that have values.
+            mlflow.set_tags({k: v for k, v in run_params.items() if v})
+            # add manually git sha for consistency with the journal
+            # TODO : this does not take into account not committed files, so it
+            # does not ensure reproducibility. Define what to do.
+            mlflow.set_tag("git_sha", _git_sha(run_params["project_path"]))
+            mlflow.set_tag(
+                "kedro_command",
+                _generate_kedro_command(
+                    tags=run_params["tags"],
+                    node_names=run_params["node_names"],
+                    from_nodes=run_params["from_nodes"],
+                    to_nodes=run_params["to_nodes"],
+                    from_inputs=run_params["from_inputs"],
+                    load_versions=run_params["load_versions"],
+                    pipeline_name=run_params["pipeline_name"],
+                ),
+            )
+        else:
+            logging.info(
+                "kedro-mlflow logging is deactivated for this pipeline in the configuration. This includes DataSets and parameters."
+            )
+            switch_catalog_logging(catalog, False)
 
     @hook_impl
     def after_pipeline_run(
@@ -131,35 +143,37 @@ class MlflowPipelineHook:
             pipeline: The ``Pipeline`` that was run.
             catalog: The ``DataCatalog`` used during the run.
         """
+        if self._is_mlflow_enabled:
+            if isinstance(pipeline, PipelineML):
+                with TemporaryDirectory() as tmp_dir:
+                    # This will be removed at the end of the context manager,
+                    # but we need to log in mlflow beforeremoving the folder
+                    pipeline_catalog = pipeline._extract_pipeline_catalog(catalog)
+                    artifacts = pipeline.extract_pipeline_artifacts(
+                        pipeline_catalog, temp_folder=Path(tmp_dir)
+                    )
 
-        if isinstance(pipeline, PipelineML):
-            with TemporaryDirectory() as tmp_dir:
-                # This will be removed at the end of the context manager,
-                # but we need to log in mlflow beforeremoving the folder
-                pipeline_catalog = pipeline._extract_pipeline_catalog(catalog)
-                artifacts = pipeline.extract_pipeline_artifacts(
-                    pipeline_catalog, temp_folder=Path(tmp_dir)
-                )
+                    if pipeline.model_signature == "auto":
+                        input_data = pipeline_catalog.load(pipeline.input_name)
+                        model_signature = infer_signature(model_input=input_data)
+                    else:
+                        model_signature = pipeline.model_signature
 
-                if pipeline.model_signature == "auto":
-                    input_data = pipeline_catalog.load(pipeline.input_name)
-                    model_signature = infer_signature(model_input=input_data)
-                else:
-                    model_signature = pipeline.model_signature
-
-                mlflow.pyfunc.log_model(
-                    artifact_path=pipeline.model_name,
-                    python_model=KedroPipelineModel(
-                        pipeline_ml=pipeline,
-                        catalog=pipeline_catalog,
-                        **pipeline.kwargs,
-                    ),
-                    artifacts=artifacts,
-                    conda_env=_format_conda_env(pipeline.conda_env),
-                    signature=model_signature,
-                )
-        # Close the mlflow active run at the end of the pipeline to avoid interactions with further runs
-        mlflow.end_run()
+                    mlflow.pyfunc.log_model(
+                        artifact_path=pipeline.model_name,
+                        python_model=KedroPipelineModel(
+                            pipeline_ml=pipeline,
+                            catalog=pipeline_catalog,
+                            **pipeline.kwargs,
+                        ),
+                        artifacts=artifacts,
+                        conda_env=_format_conda_env(pipeline.conda_env),
+                        signature=model_signature,
+                    )
+            # Close the mlflow active run at the end of the pipeline to avoid interactions with further runs
+            mlflow.end_run()
+        else:
+            switch_catalog_logging(catalog, True)
 
     @hook_impl
     def on_pipeline_error(
@@ -194,9 +208,13 @@ class MlflowPipelineHook:
             pipeline: (Not used) The ``Pipeline`` that will was run.
             catalog: (Not used) The ``DataCatalog`` used during the run.
         """
-
-        while mlflow.active_run():
-            mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
+        if self._is_mlflow_enabled:
+            while mlflow.active_run():
+                mlflow.end_run(RunStatus.to_string(RunStatus.FAILED))
+        else:  # pragma: no cover
+            # the catalog is supposed to be reloaded each time with _get_catalog,
+            # hence it should not be modified. this is only a safeguard
+            switch_catalog_logging(catalog, True)
 
 
 mlflow_pipeline_hook = MlflowPipelineHook()

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -1,0 +1,14 @@
+from kedro_mlflow.framework.context.mlflow_context import get_mlflow_config
+
+
+def _assert_mlflow_enabled(pipeline_name: str) -> bool:
+
+    mlflow_config = get_mlflow_config()
+    # TODO: we may want to enable to filter on tags
+    # but we need to deal with the case when several tags are passed
+    # what to do if 1 out of 2 is in the list?
+    disabled_pipelines = mlflow_config.disable_tracking_opts.get("pipelines") or []
+    if pipeline_name in disabled_pipelines:
+        return False
+
+    return True

--- a/kedro_mlflow/io/catalog/switch_catalog_logging.py
+++ b/kedro_mlflow/io/catalog/switch_catalog_logging.py
@@ -1,0 +1,4 @@
+def switch_catalog_logging(catalog, logging_flag=True):
+    for name, data_set in catalog._data_sets.items():
+        if type(data_set).__name__.startswith("Mlflow"):
+            catalog._data_sets[name]._logging_activated = logging_flag

--- a/kedro_mlflow/io/models/mlflow_abstract_model_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_abstract_model_dataset.py
@@ -48,6 +48,7 @@ class MlflowAbstractModelDataSet(AbstractVersionedDataSet):
 
         self._flavor = flavor
         self._pyfunc_workflow = pyfunc_workflow
+        self._logging_activated = True  # by default, it should be True!
 
         if flavor == "mlflow.pyfunc" and pyfunc_workflow not in (
             "python_model",
@@ -65,6 +66,19 @@ class MlflowAbstractModelDataSet(AbstractVersionedDataSet):
             self._mlflow_model_module
         except ImportError as err:
             raise DataSetError(err)
+
+    # we want to be able to turn logging off for an entire pipeline run
+    # To avoid that a single call to a dataset in the catalog creates a new run automatically
+    # we want to be able to turn everything off
+    @property
+    def _logging_activated(self):
+        return self.__logging_activated
+
+    @_logging_activated.setter
+    def _logging_activated(self, flag):
+        if not isinstance(flag, bool):
+            raise ValueError(f"_logging_activated must be a boolean, got {type(flag)}")
+        self.__logging_activated = flag
 
     # IMPORTANT:  _mlflow_model_module is a property to avoid STORING
     # the module as an attribute but rather store a string and load on the fly

--- a/kedro_mlflow/io/models/mlflow_model_logger_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_model_logger_dataset.py
@@ -129,13 +129,17 @@ class MlflowModelLoggerDataSet(MlflowAbstractModelDataSet):
             # workflow. We we assign the passed `model` object to one of those keys
             # depending on the chosen `pyfunc_workflow`.
             self._save_args[self._pyfunc_workflow] = model
-            self._mlflow_model_module.log_model(self._artifact_path, **self._save_args)
+            if self._logging_activated:
+                self._mlflow_model_module.log_model(
+                    self._artifact_path, **self._save_args
+                )
         else:
             # Otherwise we save using the common workflow where first argument is the
             # model object and second is the path.
-            self._mlflow_model_module.log_model(
-                model, self._artifact_path, **self._save_args
-            )
+            if self._logging_activated:
+                self._mlflow_model_module.log_model(
+                    model, self._artifact_path, **self._save_args
+                )
 
     def _describe(self) -> Dict[str, Any]:
         return dict(

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -19,6 +19,12 @@ mlflow_tracking_uri: mlruns
 
 credentials: null  # must be a valid key in credentials.yml
 
+# You can specify a list of pipeline names for which tracing will be disabled
+# Running "kedro run --pipeline=<pipeline_name>" will not log parameters
+# in a new mlflow run
+disable_tracking:
+  pipelines: []
+
 # EXPERIMENT-RELATED PARAMETERS ----------
 
 # `name` is the name of the experiment (~subfolder

--- a/tests/framework/context/test_config.py
+++ b/tests/framework/context/test_config.py
@@ -59,6 +59,7 @@ def test_kedro_mlflow_config_init(kedro_project_with_mlflow_conf):
     assert config.to_dict() == dict(
         mlflow_tracking_uri=(kedro_project_with_mlflow_conf / "mlruns").as_uri(),
         credentials=None,
+        disable_tracking=KedroMlflowConfig.DISABLE_TRACKING_OPTS,
         experiments=KedroMlflowConfig.EXPERIMENT_OPTS,
         run=KedroMlflowConfig.RUN_OPTS,
         ui=KedroMlflowConfig.UI_OPTS,

--- a/tests/framework/context/test_mlflow_context.py
+++ b/tests/framework/context/test_mlflow_context.py
@@ -27,6 +27,7 @@ def test_get_mlflow_config(kedro_project):
         dict(
             mlflow_tracking_uri="mlruns",
             credentials=None,
+            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
             experiment=dict(name="fake_package", create=True),
             run=dict(id="123456789", name="my_run", nested=True),
             ui=dict(port="5151", host="localhost"),
@@ -43,6 +44,7 @@ def test_get_mlflow_config(kedro_project):
     expected = {
         "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
         "credentials": None,
+        "disable_tracking": {"pipelines": ["my_disabled_pipeline"]},
         "experiments": {"name": "fake_package", "create": True},
         "run": {"id": "123456789", "name": "my_run", "nested": True},
         "ui": {"port": "5151", "host": "localhost"},
@@ -89,6 +91,7 @@ def test_mlflow_config_with_templated_config_loader(
         dict(
             mlflow_tracking_uri="${mlflow_tracking_uri}",
             credentials=None,
+            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
             experiment=dict(name="fake_package", create=True),
             run=dict(id="123456789", name="my_run", nested=True),
             ui=dict(port="5151", host="localhost"),
@@ -111,6 +114,7 @@ def test_mlflow_config_with_templated_config_loader(
     expected = {
         "mlflow_tracking_uri": (kedro_project_with_tcl / "dynamic_mlruns").as_uri(),
         "credentials": None,
+        "disable_tracking": {"pipelines": ["my_disabled_pipeline"]},
         "experiments": {"name": "fake_package", "create": True},
         "run": {"id": "123456789", "name": "my_run", "nested": True},
         "ui": {"port": "5151", "host": "localhost"},

--- a/tests/framework/hooks/test_all_hooks.py
+++ b/tests/framework/hooks/test_all_hooks.py
@@ -1,0 +1,310 @@
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import pytest
+import toml
+import yaml
+from kedro import __version__ as kedro_version
+from kedro.config import ConfigLoader
+from kedro.framework.hooks import hook_impl
+from kedro.framework.hooks.manager import get_hook_manager
+from kedro.framework.project import (
+    Validator,
+    _ProjectPipelines,
+    _ProjectSettings,
+    configure_project,
+)
+from kedro.framework.session import KedroSession
+from kedro.io import DataCatalog
+from kedro.pipeline import Pipeline, node
+from kedro.versioning import Journal
+from mlflow.tracking import MlflowClient
+
+from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.framework.hooks import MlflowNodeHook, MlflowPipelineHook
+
+MOCK_PACKAGE_NAME = "mock_package_name"
+
+
+def fake_fun(input):
+    artifact = input
+    metric = {
+        "metric1": {"value": 1.1, "step": 1},
+        "metric2": [{"value": 1.1, "step": 1}, {"value": 1.2, "step": 2}],
+    }
+    model = 3
+    return artifact, metric, model
+
+
+@pytest.fixture
+def kedro_project_path(tmp_path):
+    return tmp_path / MOCK_PACKAGE_NAME
+
+
+@pytest.fixture
+def local_logging_config():
+    return {
+        "version": 1,
+        "formatters": {
+            "simple": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"}
+        },
+        "root": {"level": "INFO", "handlers": ["console"]},
+        "loggers": {"kedro": {"level": "INFO", "handlers": ["console"]}},
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+                "formatter": "simple",
+                "stream": "ext://sys.stdout",
+            }
+        },
+    }
+
+
+def _write_yaml(filepath: Path, config: Dict):
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    yaml_str = yaml.dump(config)
+    filepath.write_text(yaml_str)
+
+
+def _write_toml(filepath: Path, config: Dict):
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    toml_str = toml.dumps(config)
+    filepath.write_text(toml_str)
+
+
+@pytest.fixture
+def catalog_config(kedro_project_path):
+    fake_data_filepath = str(kedro_project_path / "fake_data.pkl")
+    return {
+        "artifact_data": {
+            "type": "kedro_mlflow.io.artifacts.MlflowArtifactDataSet",
+            "data_set": {
+                "type": "pickle.PickleDataSet",
+                "filepath": fake_data_filepath,
+            },
+        },
+        "metrics_data": {
+            "type": "kedro_mlflow.io.metrics.MlflowMetricsDataSet",
+        },
+        "model": {
+            "type": "kedro_mlflow.io.models.MlflowModelLoggerDataSet",
+            "flavor": "mlflow.sklearn",
+        },
+    }
+
+
+@pytest.fixture
+def mlflow_config_wo_tracking():
+    # this is the default configuration except that oine pipeline is deactivated
+    return {
+        # "mlflow_tracking_uri": "mlruns",
+        # "credentials": None,
+        "disable_tracking": {"pipelines": ["pipeline_off"]},
+        # "experiments": MOCK_PACKAGE_NAME,
+        # "run": {"id": None, "name": None, "nested": True},
+        # "ui": {"port": None, "host": None},
+        # "hooks": {
+        #     "flatten_dict_params": False,
+        #     "recursive": True,
+        #     "sep": ".",
+        #     "long_parameters_strategy": "fail",
+        # },
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_hook_manager():
+    yield
+    hook_manager = get_hook_manager()
+    plugins = hook_manager.get_plugins()
+    for plugin in plugins:
+        hook_manager.unregister(plugin)
+
+
+@pytest.fixture(autouse=True)
+def config_dir(kedro_project_path, catalog_config, mlflow_config_wo_tracking):
+    catalog_yml = kedro_project_path / "conf" / "base" / "catalog.yml"
+    parameters_yml = kedro_project_path / "conf" / "base" / "parameters.yml"
+    credentials_yml = kedro_project_path / "conf" / "local" / "credentials.yml"
+    mlflow_yml = kedro_project_path / "conf" / "local" / "mlflow.yml"
+    # logging = tmp_path / "conf" / "local" / "logging.yml"
+    pyproject_toml = kedro_project_path / "pyproject.toml"
+    _write_yaml(catalog_yml, catalog_config)
+    _write_yaml(parameters_yml, {"a": "my_param_a"})
+    _write_yaml(mlflow_yml, mlflow_config_wo_tracking)
+    _write_yaml(credentials_yml, {})
+    # _write_yaml(logging, local_logging_config)
+    payload = {
+        "tool": {
+            "kedro": {
+                "project_version": kedro_version,
+                "project_name": MOCK_PACKAGE_NAME,
+                "package_name": MOCK_PACKAGE_NAME,
+            }
+        }
+    }
+    _write_toml(pyproject_toml, payload)
+
+
+class DummyProjectHooks:
+    @hook_impl
+    def register_config_loader(self, conf_paths: Iterable[str]) -> ConfigLoader:
+        return ConfigLoader(conf_paths)
+
+    @hook_impl
+    def register_catalog(
+        self,
+        catalog: Optional[Dict[str, Dict[str, Any]]],
+        credentials: Dict[str, Dict[str, Any]],
+        load_versions: Dict[str, str],
+        save_version: str,
+        journal: Journal,
+    ) -> DataCatalog:
+        return DataCatalog.from_config(
+            catalog, credentials, load_versions, save_version, journal
+        )
+
+
+def _mock_imported_settings_paths(mocker, mock_settings):
+    for path in [
+        "kedro.framework.context.context.settings",
+        "kedro.framework.session.session.settings",
+        "kedro.framework.project.settings",
+    ]:
+        mocker.patch(path, mock_settings)
+    return mock_settings
+
+
+def _mock_settings_with_hooks(mocker, hooks):
+    class MockSettings(_ProjectSettings):
+        _HOOKS = Validator("HOOKS", default=hooks)
+
+    return _mock_imported_settings_paths(mocker, MockSettings())
+
+
+@pytest.fixture
+def mock_settings_with_mlflow_hooks(mocker):
+
+    return _mock_settings_with_hooks(
+        mocker, hooks=(DummyProjectHooks(), MlflowPipelineHook(), MlflowNodeHook())
+    )
+
+
+@pytest.fixture(autouse=True)
+def mocked_logging(mocker):
+    # Disable logging.config.dictConfig in KedroSession._setup_logging as
+    # it changes logging.config and affects other unit tests
+    return mocker.patch("logging.config.dictConfig")
+
+
+@pytest.fixture(autouse=True)
+def mock_pipelines(mocker):
+    dummy_pipeline = Pipeline(
+        [
+            node(
+                func=fake_fun,
+                inputs=["params:a"],
+                outputs=["artifact_data", "metrics_data", "model"],
+            )
+        ]
+    )
+
+    class MockPipelines(_ProjectPipelines):
+        def _get_register_pipelines(self, pipelines_module: str):
+            return lambda: {
+                "__default__": dummy_pipeline,
+                "pipeline_off": dummy_pipeline,
+                "pipeline_on": dummy_pipeline,
+            }
+
+    dummy_pipelines = MockPipelines()
+    mocker.patch("kedro.framework.context.context.pipelines", dummy_pipelines)
+    return mocker.patch("kedro.framework.project.pipelines", dummy_pipelines)
+
+
+@pytest.fixture
+def patched_configure_project(mocker):
+    mocker.patch("kedro.framework.project._validate_module")
+    # prevent registering the one of the plugins which are already installed
+    mocker.patch("kedro.framework.project._register_hooks_setuptools")
+    configure_project(MOCK_PACKAGE_NAME)
+    yield
+
+
+def test_deactivated_tracking_but_not_for_given_pipeline(
+    mock_settings_with_mlflow_hooks,
+    patched_configure_project,
+    mocker,
+    kedro_project_path,
+):
+
+    mocker.patch("kedro.framework.session.session.KedroSession._setup_logging")
+
+    with KedroSession.create(MOCK_PACKAGE_NAME, kedro_project_path) as session:
+
+        kedro_mlflow_config = get_mlflow_config()
+        kedro_mlflow_config.setup()
+
+        mlflow_client = MlflowClient((kedro_project_path / "mlruns").as_uri())
+
+        # 0 is default, 1 is "fake_exp"
+        all_runs_id_beginning = set(
+            [
+                run.run_id
+                for k in range(len(mlflow_client.list_experiments()))
+                for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+            ]
+        )
+
+        context = session.load_context()
+        context.run(pipeline_name="pipeline_on")  # this is a pipeline should be tracked
+
+        all_runs_id_end = set(
+            [
+                run.run_id
+                for k in range(len(mlflow_client.list_experiments()))
+                for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+            ]
+        )
+
+        assert len(all_runs_id_end - all_runs_id_beginning) == 1  # 1 run is created
+
+
+def test_deactivated_tracking_for_given_pipeline(
+    mock_settings_with_mlflow_hooks,
+    patched_configure_project,
+    mocker,
+    kedro_project_path,
+):
+
+    mocker.patch("kedro.framework.session.session.KedroSession._setup_logging")
+
+    with KedroSession.create(MOCK_PACKAGE_NAME, kedro_project_path) as session:
+
+        kedro_mlflow_config = get_mlflow_config()
+        kedro_mlflow_config.setup()
+
+        mlflow_client = MlflowClient((kedro_project_path / "mlruns").as_uri())
+
+        # 0 is default, 1 is "fake_exp"
+        all_runs_id_beginning = set(
+            [
+                run.run_id
+                for k in range(len(mlflow_client.list_experiments()))
+                for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+            ]
+        )
+
+        context = session.load_context()
+        context.run(pipeline_name="pipeline_off")
+
+        all_runs_id_end = set(
+            [
+                run.run_id
+                for k in range(len(mlflow_client.list_experiments()))
+                for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+            ]
+        )
+
+        assert all_runs_id_beginning == all_runs_id_end  # no run is created

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -709,7 +709,7 @@ def test_on_pipeline_error(kedro_project_with_mlflow_conf):
         class DummyContextWithHook(KedroContext):
             project_name = "fake project"
             package_name = "fake_project"
-            project_version = "0.16.0"
+            project_version = "0.16.5"
 
             hooks = (MlflowPipelineHook(),)
 

--- a/tests/io/metrics/test_mlflow_metrics_dataset.py
+++ b/tests/io/metrics/test_mlflow_metrics_dataset.py
@@ -169,3 +169,39 @@ def test_mlflow_metrics_dataset_fails_with_invalid_metric(
         mlflow_metrics_dataset.save(
             {"metric1": 1}
         )  # key: value is not valid, you must specify {key: {value, step}}
+
+
+def test_mlflow_artifact_logging_deactivation(tracking_uri, metrics):
+    mlflow_metrics_dataset = MlflowMetricsDataSet(prefix="hello")
+
+    mlflow.set_tracking_uri(tracking_uri.as_uri())
+    mlflow_client = MlflowClient(tracking_uri=tracking_uri.as_uri())
+
+    mlflow_metrics_dataset._logging_activated = False
+
+    all_runs_id_beginning = set(
+        [
+            run.run_id
+            for k in range(len(mlflow_client.list_experiments()))
+            for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+        ]
+    )
+
+    mlflow_metrics_dataset.save(metrics)
+
+    all_runs_id_end = set(
+        [
+            run.run_id
+            for k in range(len(mlflow_client.list_experiments()))
+            for run in mlflow_client.list_run_infos(experiment_id=f"{k}")
+        ]
+    )
+
+    assert all_runs_id_beginning == all_runs_id_end
+
+
+def test_mlflow_metrics_logging_deactivation_is_bool():
+    mlflow_metrics_dataset = MlflowMetricsDataSet(prefix="hello")
+
+    with pytest.raises(ValueError, match="_logging_activated must be a boolean"):
+        mlflow_metrics_dataset._logging_activated = "hello"

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -30,9 +30,10 @@ def test_mlflow_yml_rendering(template_mlflowyml):
     expected_config = dict(
         mlflow_tracking_uri="mlruns",
         credentials=None,
+        disable_tracking=KedroMlflowConfig.DISABLE_TRACKING_OPTS,
+        experiment=KedroMlflowConfig.EXPERIMENT_OPTS,
         ui=KedroMlflowConfig.UI_OPTS,
         run=KedroMlflowConfig.RUN_OPTS,
-        experiment=KedroMlflowConfig.EXPERIMENT_OPTS,
         hooks=dict(node=KedroMlflowConfig.NODE_HOOK_OPTS),
     )
     expected_config["experiment"]["name"] = "fake_project"  # check for proper rendering


### PR DESCRIPTION
## Description

Implement partially #92 by adding the possibility to deactivate mlflow tracking in the configuration file.

## Development notes
- [X] Add a test in the hooks to see if mlflow is activated
- [X] Update KedroMlflowConfig to add a key to parameterize trigger for mlflow deactivation
- [X] Modify MlflowArtifactDataSet, MlflowMetricsDataSet and MlflowModelLoggerDataSet to be able to turn logging off temporarily (with a private property)
- [X] Add tests
- [x] Add a logger info when mlflow_tracking is deactivated

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
