### PR TITLE
FIX #187 - Pass host and port parameters from the configuration to the ui command and enable runtime overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 -   It is now possible to deactivate tracking (for parameters and datasets) by specifying a key `disabled_tracking: pipelines: [<pipeline-name>]` in the `mlflow.yml` configuration file. ([#92](https://github.com/Galileo-Galilei/kedro-mlflow/issues/92))
 
+- The `kedro mlflow ui` command `host` and `port` keys can be overwritten at runtime ([#187](https://github.com/Galileo-Galilei/kedro-mlflow/issues/187))
+
+### Fixed
+
+- The `kedro mlflow ui` now reads properly the `ui:host` and `ui:port` keys from the `mlflow.yml` which were incorrectly ignored ([#187](https://github.com/Galileo-Galilei/kedro-mlflow/issues/187))
+
 ## [0.7.0] - 2021-03-17
 
 ### Added

--- a/docs/source/04_experimentation_tracking/01_configuration.md
+++ b/docs/source/04_experimentation_tracking/01_configuration.md
@@ -47,7 +47,7 @@ and your can supply the credentials key of the `mlflow.yml`:
 credentials: my_mlflow_credentials
 ```
 
-For safety reasons, the credentials will not be accessible within `KedroMlflowConfig` objects. They wil be exported as environment variables *on the fly* when running the pipeline.
+For safety reasons, the credentials will not be accessible within `KedroMlflowConfig` objects. They will be exported as environment variables *on the fly* when running the pipeline.
 
 ### Deactivate tracking under conditions
 

--- a/docs/source/07_python_objects/04_CLI.md
+++ b/docs/source/07_python_objects/04_CLI.md
@@ -4,12 +4,32 @@
 
  ``kedro mlflow init``: this command is needed to initalize your project. You cannot run any other commands before you run this one once. It performs 2 actions:
     - creates a ``mlflow.yml`` configuration file in your ``conf/local`` folder
-    - replace the ``src/PYTHON_PACKAGE/run.py`` file by an updated version of the template. If your template has been modified since project creation, a warning wil be raised. You can either run ``kedro mlflow init --force`` to ignore this warning (but this will erase your ``run.py``) or [set hooks manually](#new-hooks).
+    - replace the ``src/PYTHON_PACKAGE/run.py`` file by an updated version of the template. If your template has been modified since project creation, a warning will be raised. You can either run ``kedro mlflow init --force`` to ignore this warning (but this will erase your ``run.py``) or [set hooks manually](#new-hooks).
 
-Init has two arguments:
+`init` has two arguments:
+
 - `--env` which enable to specifiy another environment where the mlflow.yml should be created (e.g, `base`)
 - `--force` which overrides the `mlflow.yml` if it already exists and replaces it with the default one. Use it with caution!
 
 ## ``ui``
 
-``kedro mlflow ui``: this command opens the mlflow UI (basically launches the ``mlflow ui`` command with the configuration of your ``mlflow.yml`` file)
+``kedro mlflow ui``: this command opens the mlflow UI (basically launches the ``mlflow ui`` command )
+
+`ui` accepts the port and host arguments of [``mlflow ui`` command](https://www.mlflow.org/docs/latest/cli.html#mlflow-ui). The default values used will be the ones defined in the [``mlflow.yml`` configuration file under the `ui`](../04_experimentation_tracking/01_configuration.md#configure-the-user-interface).
+
+If you provide the arguments at runtime, they wil take priority over the ``mlflow.yml``, e.g. if you have:
+
+```yaml
+# mlflow.yml
+ui:
+    localhost: "0.0.0.0"
+    port: "5001"
+```
+
+then
+
+```console
+kedro mlflow ui --port=5002
+```
+
+will open the ui on port 5002.

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -129,7 +129,19 @@ def init(env, force, silent):
     default="local",
     help="The environment within conf folder we want to retrieve.",
 )
-def ui(env):
+@click.option(
+    "--port",
+    "-p",
+    required=False,
+    help="The port to listen on",
+)
+@click.option(
+    "--host",
+    "-h",
+    required=False,
+    help="The network address to listen on (default: 127.0.0.1). Use 0.0.0.0 to bind to all addresses if you want to access the tracking server from other machines.",
+)
+def ui(env, port, host):
     """Opens the mlflow user interface with the
     project-specific settings of mlflow.yml. This interface
     enables to browse and compares runs.
@@ -146,11 +158,22 @@ def ui(env):
     ):
 
         mlflow_conf = get_mlflow_config()
+        host = host or mlflow_conf.ui_opts.get("host")
+        port = port or mlflow_conf.ui_opts.get("port")
 
         # call mlflow ui with specific options
         # TODO : add more options for ui
         subprocess.call(
-            ["mlflow", "ui", "--backend-store-uri", mlflow_conf.mlflow_tracking_uri]
+            [
+                "mlflow",
+                "ui",
+                "--backend-store-uri",
+                mlflow_conf.mlflow_tracking_uri,
+                "--host",
+                host,
+                "--port",
+                port,
+            ]
         )
 
 

--- a/kedro_mlflow/framework/context/config.py
+++ b/kedro_mlflow/framework/context/config.py
@@ -18,7 +18,7 @@ class KedroMlflowConfig:
 
     RUN_OPTS = {"id": None, "name": None, "nested": True}
 
-    UI_OPTS = {"port": None, "host": None}
+    UI_OPTS = {"port": "5000", "host": "127.0.0.1"}
 
     NODE_HOOK_OPTS = {
         "flatten_dict_params": False,

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -53,5 +53,5 @@ hooks:
 # UI-RELATED PARAMETERS -----------------
 
 ui:
-  port: null  # the port to use for the ui. Find a free port if null.
-  host: null  # the host to use for the ui. Default to "localhost" if null.
+  port: "5000" # the port to use for the ui. Use mlflow default with 5000.
+  host: "127.0.0.1"  # the host to use for the ui. Use mlflow efault of "127.0.0.1".

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -170,7 +170,18 @@ def test_ui_is_up(monkeypatch, mocker, kedro_project_with_mlflow_conf):
         "subprocess.call"
     )  # make the test succeed, but no a real test
     cli_runner.invoke(cli_ui)
-    ui_mocker.assert_called_once()
+    ui_mocker.assert_called_once_with(
+        [
+            "mlflow",
+            "ui",
+            "--backend-store-uri",
+            (kedro_project_with_mlflow_conf / "mlruns").as_uri(),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "5000",
+        ]
+    )
 
     # OTHER ATTEMPT:
     # try:
@@ -181,3 +192,29 @@ def test_ui_is_up(monkeypatch, mocker, kedro_project_with_mlflow_conf):
     #     raise err
     # print(thread)
     # assert thread.is_alive()
+
+
+def test_ui_overwrite_conf_at_runtime(
+    monkeypatch, mocker, kedro_project_with_mlflow_conf
+):
+
+    monkeypatch.chdir(kedro_project_with_mlflow_conf)
+    cli_runner = CliRunner()
+
+    # This does not test anything : the goal is to check whether it raises an error
+    ui_mocker = mocker.patch(
+        "subprocess.call"
+    )  # make the test succeed, but no a real test
+    cli_runner.invoke(cli_ui, ["--host", "0.0.0.0", "--port", "5001"])
+    ui_mocker.assert_called_once_with(
+        [
+            "mlflow",
+            "ui",
+            "--backend-store-uri",
+            (kedro_project_with_mlflow_conf / "mlruns").as_uri(),
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "5001",
+        ]
+    )


### PR DESCRIPTION
## Description

Fix #187 

## Development notes

- Change default port and host configuration to match mlflow's ones (in the `mlflow.yml` template and in `KedroMlflowConfig`)
- Pass `host` and `port` to when calling `mlflow ui` inside `kedro mlflow ui`
- Add `host` and `port` arguments to `ui`  to enable to overwrite these parameters at runtime

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
