### PR TITLE
FIX #193 - Remove global commands to make project CLI commands available again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove global CLI command `new` (which was not implemented yet) to make project CLI commands available. It is not possible to have 2 CLI groups (one at global level , one at project level) because of a bug in ``kedro==0.17.3`` ([#193](https://github.com/Galileo-Galilei/kedro-mlflow/issues/193))
+
 ## [0.7.1] - 2021-04-09
 
 ### Added
@@ -12,7 +16,7 @@
 
 ### Fixed
 
--   The `kedro mlflow ui` now reads properly the `ui:host` and `ui:port` keys from the `mlflow.yml` which were incorrectly ignored ([#187](https://github.com/Galileo-Galilei/kedro-mlflow/issues/187))
+-   The `kedro mlflow ui` command now reads properly the `ui:host` and `ui:port` keys from the `mlflow.yml` which were incorrectly ignored ([#187](https://github.com/Galileo-Galilei/kedro-mlflow/issues/187))
 
 ## [0.7.0] - 2021-03-17
 

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,9 @@ setup(
         "kedro.project_commands": [
             "kedro_mlflow =  kedro_mlflow.framework.cli.cli:commands"
         ],
-        "kedro.global_commands": [
-            "kedro_mlflow =  kedro_mlflow.framework.cli.cli:commands"
-        ],
+        # "kedro.global_commands": [
+        #     "kedro_mlflow =  kedro_mlflow.framework.cli.cli:commands"
+        # ],
         "kedro.hooks": [
             "mlflow_pipeline_hook = kedro_mlflow.framework.hooks.pipeline_hook:mlflow_pipeline_hook",
             "mlflow_node_hooks = kedro_mlflow.framework.hooks.node_hook:mlflow_node_hook",


### PR DESCRIPTION
## Description
Fix #193 

## Development notes
Remove the global group of commands in the setup.py, because ``kedro==0.17.3`` is bugged and no longer supports having both global and project commands.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
