### PR TITLE
Migration/test to 0.17.3

### DIFF
--- a/docs/source/01_introduction/01_introduction.md
+++ b/docs/source/01_introduction/01_introduction.md
@@ -47,7 +47,7 @@ We discuss hereafter how the two libraries compete on the different functionalit
 
 ### Versioning: Kedro 1 - 1 Mlflow
 
-The ``Kedro`` [``Journal`` aims at reproducibility](https://kedro.readthedocs.io/en/latest/kedro.versioning.Journal.html), but is not focused on machine learning. The `Journal` keeps track of two elements:
+The ``Kedro`` [``Journal`` aims at reproducibility](https://kedro.readthedocs.io/en/latest/kedro.versioning.journal.Journal.html), but is not focused on machine learning. The `Journal` keeps track of two elements:
 
 - the CLI arguments, including *on the fly* parameters. This makes the command used to run the pipeline fully reproducible.
 - the ``AbstractVersionedDataSet`` for which versioning is activated. It consists in copying the data whom ``versioned`` argument is ``True`` when the ``save`` method of the ``AbstractVersionedDataSet`` is called.

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -2,10 +2,8 @@ import subprocess
 from pathlib import Path
 
 import click
-from kedro.framework.cli.utils import _add_src_to_path
-from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import _get_project_metadata, _is_project
+from kedro.framework.startup import _is_project, bootstrap_project
 
 from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
 from kedro_mlflow.framework.context import get_mlflow_config
@@ -79,12 +77,8 @@ def init(env, force, silent):
     # get constants
     mlflow_yml = "mlflow.yml"
     project_path = Path().cwd()
-    project_metadata = _get_project_metadata(project_path)
-    _add_src_to_path(project_metadata.source_dir, project_path)
-    configure_project(project_metadata.package_name)
-    session = KedroSession.create(
-        project_metadata.package_name, project_path=project_path
-    )
+    project_metadata = bootstrap_project(project_path)
+    session = KedroSession.create(project_path=project_path)
     context = session.load_context()
     mlflow_yml_path = project_path / context.CONF_ROOT / env / mlflow_yml
 
@@ -148,11 +142,8 @@ def ui(env, port, host):
     """
 
     project_path = Path().cwd()
-    project_metadata = _get_project_metadata(project_path)
-    _add_src_to_path(project_metadata.source_dir, project_path)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(project_path)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=project_path,
         env=env,
     ):

--- a/kedro_mlflow/framework/context/config.py
+++ b/kedro_mlflow/framework/context/config.py
@@ -4,7 +4,7 @@ from pathlib import Path, PurePath
 from typing import Any, Dict, Optional, Union
 
 import mlflow
-from kedro.framework.session.session import get_current_session
+from kedro.framework.session.session import KedroSession, get_current_session
 from kedro.framework.startup import _is_project
 
 LOGGER = logging.getLogger(__name__)
@@ -78,10 +78,10 @@ class KedroMlflowConfig:
         )
         self.from_dict(configuration)
 
-    def setup(self):
+    def setup(self, session: KedroSession = None):
         """Setup all the mlflow configuration"""
 
-        self._export_credentials()
+        self._export_credentials(session)
 
         # we set the configuration now: it takes priority
         # if it has already be set in export_credentials
@@ -263,8 +263,8 @@ class KedroMlflowConfig:
 
         return valid_uri
 
-    def _export_credentials(self):
-        session = get_current_session()
+    def _export_credentials(self, session: KedroSession = None):
+        session = session or get_current_session()
         context = session.load_context()
         conf_creds = context._get_config_credentials()
         mlflow_creds = conf_creds.get(self.credentials, {})

--- a/tests/framework/context/test_config.py
+++ b/tests/framework/context/test_config.py
@@ -3,10 +3,8 @@ import os
 import mlflow
 import pytest
 import yaml
-from kedro.framework.cli.utils import _add_src_to_path
-from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import _get_project_metadata
+from kedro.framework.startup import bootstrap_project
 from mlflow.tracking import MlflowClient
 
 from kedro_mlflow.framework.context.config import (
@@ -90,12 +88,8 @@ def test_kedro_mlflow_config_new_experiment_does_not_exists(
         experiment_opts=dict(name="exp1"),
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
 
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
@@ -114,12 +108,8 @@ def test_kedro_mlflow_config_experiment_exists(mocker, kedro_project_with_mlflow
         experiment_opts=dict(name="exp1"),
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
 
@@ -141,12 +131,8 @@ def test_kedro_mlflow_config_experiment_was_deleted(kedro_project_with_mlflow_co
         experiment_opts=dict(name="exp1"),
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
 
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
@@ -164,12 +150,8 @@ def test_kedro_mlflow_config_setup_set_tracking_uri(kedro_project_with_mlflow_co
         experiment_opts=dict(name="exp1"),
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
 
     assert mlflow.get_tracking_uri() == mlflow_tracking_uri
@@ -186,12 +168,8 @@ def test_kedro_mlflow_config_setup_export_credentials(kedro_project_with_mlflow_
         project_path=kedro_project_with_mlflow_conf, credentials="my_mlflow_creds"
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
 
     assert os.environ["fake_mlflow_cred"] == "my_fake_cred"
@@ -217,12 +195,8 @@ def test_kedro_mlflow_config_setup_tracking_priority(kedro_project_with_mlflow_c
         credentials="my_mlflow_creds",
     )
 
-    project_metadata = _get_project_metadata(kedro_project_with_mlflow_conf)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_mlflow_conf)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(
-        "fake_project", project_path=kedro_project_with_mlflow_conf
-    ):
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
         config.setup()
 
     assert (

--- a/tests/framework/context/test_mlflow_context.py
+++ b/tests/framework/context/test_mlflow_context.py
@@ -1,9 +1,7 @@
 import pytest
 import yaml
-from kedro.framework.cli.utils import _add_src_to_path
-from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import _get_project_metadata
+from kedro.framework.startup import bootstrap_project
 
 from kedro_mlflow.framework.context import get_mlflow_config
 from kedro_mlflow.framework.context.config import KedroMlflowConfigError
@@ -58,10 +56,8 @@ def test_get_mlflow_config(kedro_project):
         },
     }
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(project_metadata.package_name, project_path=kedro_project):
+    bootstrap_project(kedro_project)
+    with KedroSession.create(project_path=kedro_project):
         assert get_mlflow_config().to_dict() == expected
 
 
@@ -70,10 +66,8 @@ def test_get_mlflow_config_in_uninitialized_project(kedro_project):
     with pytest.raises(
         KedroMlflowConfigError, match="No 'mlflow.yml' config file found in environment"
     ):
-        project_metadata = _get_project_metadata(kedro_project)
-        _add_src_to_path(project_metadata.source_dir, kedro_project)
-        configure_project(project_metadata.package_name)
-        with KedroSession.create(project_metadata.package_name, kedro_project):
+        bootstrap_project(kedro_project)
+        with KedroSession.create(project_path=kedro_project):
             get_mlflow_config()
 
 
@@ -127,8 +121,6 @@ def test_mlflow_config_with_templated_config_loader(
             }
         },
     }
-    project_metadata = _get_project_metadata(kedro_project_with_tcl)
-    _add_src_to_path(project_metadata.source_dir, kedro_project_with_tcl)
-    configure_project(project_metadata.package_name)
-    with KedroSession.create(project_metadata.package_name, kedro_project_with_tcl):
+    bootstrap_project(kedro_project_with_tcl)
+    with KedroSession.create(project_path=kedro_project_with_tcl):
         assert get_mlflow_config().to_dict() == expected

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -4,10 +4,8 @@ from typing import Dict
 import mlflow
 import pytest
 import yaml
-from kedro.framework.cli.utils import _add_src_to_path
-from kedro.framework.project import configure_project
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import _get_project_metadata
+from kedro.framework.startup import bootstrap_project
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
 from mlflow.tracking import MlflowClient
@@ -122,11 +120,8 @@ def test_pipeline_run_hook_getting_configs(
         ),
     ),
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         mlflow_node_hook = MlflowNodeHook()
@@ -187,11 +182,8 @@ def test_node_hook_logging(
 
     mlflow_tracking_uri = (kedro_project / "mlruns").as_uri()
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         mlflow.set_tracking_uri(mlflow_tracking_uri)
@@ -238,11 +230,8 @@ def test_node_hook_logging_below_limit_all_strategy(
     param_value = param_length * "a"
     node_inputs = {"params:my_param": param_value}
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         with mlflow.start_run():
@@ -288,11 +277,8 @@ def test_node_hook_logging_above_limit_truncate_strategy(
     param_value = param_length * "a"
     node_inputs = {"params:my_param": param_value}
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         with mlflow.start_run():
@@ -340,11 +326,8 @@ def test_node_hook_logging_above_limit_fail_strategy(
     param_value = param_length * "a"
     node_inputs = {"params:my_param": param_value}
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         with mlflow.start_run():
@@ -396,11 +379,8 @@ def test_node_hook_logging_above_limit_tag_strategy(
     param_value = param_length * "a"
     node_inputs = {"params:my_param": param_value}
 
-    project_metadata = _get_project_metadata(kedro_project)
-    _add_src_to_path(project_metadata.source_dir, kedro_project)
-    configure_project(project_metadata.package_name)
+    bootstrap_project(kedro_project)
     with KedroSession.create(
-        package_name=project_metadata.package_name,
         project_path=kedro_project,
     ):
         with mlflow.start_run():


### PR DESCRIPTION
## Description

Tests were failing with kedro==0.17.3 due to new pipeline import system

## Development notes
 
- update hooks and pipeline tests
- enable KedroMlflowConfig.setup method to take a session as an argument instead of fetching the active one.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- N/A Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
