### PR TITLE
Fix error when logging a dictionnary parameters with integer keys (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- :bug: Dictionnary parameters with integer keys are now properly logged in mlflow when ``flatten_dict_params`` is set to ``True`` in the ``mlflow.yml`` instead of raising a ``TypeError`` ([#224](https://github.com/Galileo-Galilei/kedro-mlflow/discussions/224))
+
 ## [0.7.3] - 2021-08-16
 
 ### Added
@@ -224,14 +228,6 @@ Many documentation improvements:
 
 [0.6.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.5.0...0.6.0
 
-[0.2.1]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.2.0...0.2.1
-
-[0.2.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.1.0...0.2.0
-
-[0.1.0]: https://github.com/Galileo-Galilei/kedro-mlflow/releases/tag/0.1.0
-
-[Unreleased]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.5.0...HEAD
-
 [0.5.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.4.1...0.5.0
 
 [0.4.1]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.4.0...0.4.1
@@ -239,3 +235,9 @@ Many documentation improvements:
 [0.4.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.3.0...0.4.0
 
 [0.3.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.2.1...0.3.0
+
+[0.2.1]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.2.0...0.2.1
+
+[0.2.0]: https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.1.0...0.2.0
+
+[0.1.0]: https://github.com/Galileo-Galilei/kedro-mlflow/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - :bug: Dictionnary parameters with integer keys are now properly logged in mlflow when ``flatten_dict_params`` is set to ``True`` in the ``mlflow.yml`` instead of raising a ``TypeError`` ([#224](https://github.com/Galileo-Galilei/kedro-mlflow/discussions/224))
 
+### Changed
+
+- :recycle: Move ``flatten_dict`` function to ``hooks.utils`` folder and rename it ``_flatten_dict`` to make more explicit that it is not a user facing function which should not be used directly.
+
+
 ## [0.7.3] - 2021-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Fixed
 
 - :bug: Dictionnary parameters with integer keys are now properly logged in mlflow when ``flatten_dict_params`` is set to ``True`` in the ``mlflow.yml`` instead of raising a ``TypeError`` ([#224](https://github.com/Galileo-Galilei/kedro-mlflow/discussions/224))
+- :bug: The user defined ``sep`` parameter of the ``mlflow.yml`` (defined in ``node`` section) is now used even if the parameters dictionnary has a depth>=2 ([#230](https://github.com/Galileo-Galilei/kedro-mlflow/issues/230))
 
 ### Changed
 
-- :recycle: Move ``flatten_dict`` function to ``hooks.utils`` folder and rename it ``_flatten_dict`` to make more explicit that it is not a user facing function which should not be used directly.
+- :recycle: Move ``flatten_dict`` function to ``hooks.utils`` folder and rename it ``_flatten_dict`` to make more explicit that it is not a user facing function which should not be used directly and comes with no guarantee. This is not considered as a breaking change since it is an undocumented function.
 
 
 ## [0.7.3] - 2021-08-16

--- a/kedro_mlflow/framework/hooks/node_hook.py
+++ b/kedro_mlflow/framework/hooks/node_hook.py
@@ -9,7 +9,7 @@ from kedro.pipeline.node import Node
 from mlflow.utils.validation import MAX_PARAM_VAL_LENGTH
 
 from kedro_mlflow.framework.context import get_mlflow_config
-from kedro_mlflow.framework.hooks.utils import _assert_mlflow_enabled
+from kedro_mlflow.framework.hooks.utils import _assert_mlflow_enabled, _flatten_dict
 
 
 class MlflowNodeHook:
@@ -93,7 +93,7 @@ class MlflowNodeHook:
 
             # dictionary parameters may be flattened for readibility
             if self.flatten:
-                params_inputs = flatten_dict(
+                params_inputs = _flatten_dict(
                     d=params_inputs, recursive=self.recursive, sep=self.sep
                 )
 
@@ -128,16 +128,3 @@ class MlflowNodeHook:
 
 # this hooks instaitation is necessary for auto-registration
 mlflow_node_hook = MlflowNodeHook()
-
-
-def flatten_dict(d: Dict, recursive: bool = True, sep: str = ".") -> Dict:
-    def expand(key, value):
-        if isinstance(value, dict):
-            new_value = flatten_dict(value) if recursive else value
-            return [(f"{key}{sep}{k}", v) for k, v in new_value.items()]
-        else:
-            return [(f"{key}", value)]
-
-    items = [item for k, v in d.items() for item in expand(k, v)]
-
-    return dict(items)

--- a/kedro_mlflow/framework/hooks/node_hook.py
+++ b/kedro_mlflow/framework/hooks/node_hook.py
@@ -130,13 +130,13 @@ class MlflowNodeHook:
 mlflow_node_hook = MlflowNodeHook()
 
 
-def flatten_dict(d, recursive: bool = True, sep="."):
+def flatten_dict(d: Dict, recursive: bool = True, sep: str = ".") -> Dict:
     def expand(key, value):
         if isinstance(value, dict):
             new_value = flatten_dict(value) if recursive else value
-            return [(key + sep + k, v) for k, v in new_value.items()]
+            return [(f"{key}{sep}{k}", v) for k, v in new_value.items()]
         else:
-            return [(key, value)]
+            return [(f"{key}", value)]
 
     items = [item for k, v in d.items() for item in expand(k, v)]
 

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from kedro_mlflow.framework.context.mlflow_context import get_mlflow_config
 
 
@@ -12,3 +14,16 @@ def _assert_mlflow_enabled(pipeline_name: str) -> bool:
         return False
 
     return True
+
+
+def _flatten_dict(d: Dict, recursive: bool = True, sep: str = ".") -> Dict:
+    def expand(key, value):
+        if isinstance(value, dict):
+            new_value = _flatten_dict(value) if recursive else value
+            return [(f"{key}{sep}{k}", v) for k, v in new_value.items()]
+        else:
+            return [(f"{key}", value)]
+
+    items = [item for k, v in d.items() for item in expand(k, v)]
+
+    return dict(items)

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -19,7 +19,11 @@ def _assert_mlflow_enabled(pipeline_name: str) -> bool:
 def _flatten_dict(d: Dict, recursive: bool = True, sep: str = ".") -> Dict:
     def expand(key, value):
         if isinstance(value, dict):
-            new_value = _flatten_dict(value) if recursive else value
+            new_value = (
+                _flatten_dict(value, recursive=recursive, sep=sep)
+                if recursive
+                else value
+            )
             return [(f"{key}{sep}{k}", v) for k, v in new_value.items()]
         else:
             return [(f"{key}", value)]

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -50,6 +50,42 @@ def test_flatten_dict_nested_2_levels():
     }
 
 
+def test_flatten_dict_nested_3_levels():
+    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=dict(g=4, h=5))))
+
+    assert flatten_dict(d=d, recursive=True, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d.e": 3,
+        "b.d.f.g": 4,
+        "b.d.f.h": 5,
+    }
+    assert flatten_dict(d=d, recursive=False, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d": {"e": 3, "f": {"g": 4, "h": 5}},
+    }
+
+
+def test_flatten_dict_with_float_keys():
+    d = {0: 1, 1: {3: 1, 4: {"e": 3, 6.7: 5}}}
+
+    assert flatten_dict(d=d, recursive=True, sep="_") == {
+        "0": 1,
+        "1_3": 1,
+        "1_4_e": 3,
+        "1_4_6.7": 5,
+    }
+    assert flatten_dict(d=d, recursive=False, sep="_") == {
+        "0": 1,
+        "1_3": 1,
+        "1_4": {
+            "e": 3,
+            6.7: 5,  # 6.7 is not converted to string, but when the entire dict will be logged mlflow will take care of the conversion
+        },
+    }
+
+
 @pytest.fixture
 def dummy_run_params(tmp_path):
     dummy_run_params = {

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -12,78 +12,12 @@ from mlflow.tracking import MlflowClient
 from mlflow.utils.validation import MAX_PARAM_VAL_LENGTH
 
 from kedro_mlflow.framework.hooks import MlflowNodeHook
-from kedro_mlflow.framework.hooks.node_hook import flatten_dict
 
 
 def _write_yaml(filepath: Path, config: Dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
     yaml_str = yaml.dump(config)
     filepath.write_text(yaml_str)
-
-
-def test_flatten_dict_non_nested():
-    d = dict(a=1, b=2)
-    assert flatten_dict(d=d, recursive=True, sep=".") == d
-    assert flatten_dict(d=d, recursive=False, sep=".") == d
-
-
-def test_flatten_dict_nested_1_level():
-    d = dict(a=1, b=dict(c=3, d=4))
-    flattened = {"a": 1, "b.c": 3, "b.d": 4}
-    assert flatten_dict(d=d, recursive=True, sep=".") == flattened
-    assert flatten_dict(d=d, recursive=False, sep=".") == flattened
-
-
-def test_flatten_dict_nested_2_levels():
-    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=5)))
-
-    assert flatten_dict(d=d, recursive=True, sep=".") == {
-        "a": 1,
-        "b.c": 1,
-        "b.d.e": 3,
-        "b.d.f": 5,
-    }
-    assert flatten_dict(d=d, recursive=False, sep=".") == {
-        "a": 1,
-        "b.c": 1,
-        "b.d": {"e": 3, "f": 5},
-    }
-
-
-def test_flatten_dict_nested_3_levels():
-    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=dict(g=4, h=5))))
-
-    assert flatten_dict(d=d, recursive=True, sep=".") == {
-        "a": 1,
-        "b.c": 1,
-        "b.d.e": 3,
-        "b.d.f.g": 4,
-        "b.d.f.h": 5,
-    }
-    assert flatten_dict(d=d, recursive=False, sep=".") == {
-        "a": 1,
-        "b.c": 1,
-        "b.d": {"e": 3, "f": {"g": 4, "h": 5}},
-    }
-
-
-def test_flatten_dict_with_float_keys():
-    d = {0: 1, 1: {3: 1, 4: {"e": 3, 6.7: 5}}}
-
-    assert flatten_dict(d=d, recursive=True, sep="_") == {
-        "0": 1,
-        "1_3": 1,
-        "1_4_e": 3,
-        "1_4_6.7": 5,
-    }
-    assert flatten_dict(d=d, recursive=False, sep="_") == {
-        "0": 1,
-        "1_3": 1,
-        "1_4": {
-            "e": 3,
-            6.7: 5,  # 6.7 is not converted to string, but when the entire dict will be logged mlflow will take care of the conversion
-        },
-    }
 
 
 @pytest.fixture

--- a/tests/framework/hooks/test_utils.py
+++ b/tests/framework/hooks/test_utils.py
@@ -1,0 +1,66 @@
+from kedro_mlflow.framework.hooks.utils import _flatten_dict
+
+
+def test_flatten_dict_non_nested():
+    d = dict(a=1, b=2)
+    assert _flatten_dict(d=d, recursive=True, sep=".") == d
+    assert _flatten_dict(d=d, recursive=False, sep=".") == d
+
+
+def test_flatten_dict_nested_1_level():
+    d = dict(a=1, b=dict(c=3, d=4))
+    flattened = {"a": 1, "b.c": 3, "b.d": 4}
+    assert _flatten_dict(d=d, recursive=True, sep=".") == flattened
+    assert _flatten_dict(d=d, recursive=False, sep=".") == flattened
+
+
+def test_flatten_dict_nested_2_levels():
+    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=5)))
+
+    assert _flatten_dict(d=d, recursive=True, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d.e": 3,
+        "b.d.f": 5,
+    }
+    assert _flatten_dict(d=d, recursive=False, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d": {"e": 3, "f": 5},
+    }
+
+
+def test_flatten_dict_nested_3_levels():
+    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=dict(g=4, h=5))))
+
+    assert _flatten_dict(d=d, recursive=True, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d.e": 3,
+        "b.d.f.g": 4,
+        "b.d.f.h": 5,
+    }
+    assert _flatten_dict(d=d, recursive=False, sep=".") == {
+        "a": 1,
+        "b.c": 1,
+        "b.d": {"e": 3, "f": {"g": 4, "h": 5}},
+    }
+
+
+def test_flatten_dict_with_float_keys():
+    d = {0: 1, 1: {3: 1, 4: {"e": 3, 6.7: 5}}}
+
+    assert _flatten_dict(d=d, recursive=True, sep="_") == {
+        "0": 1,
+        "1_3": 1,
+        "1_4_e": 3,
+        "1_4_6.7": 5,
+    }
+    assert _flatten_dict(d=d, recursive=False, sep="_") == {
+        "0": 1,
+        "1_3": 1,
+        "1_4": {
+            "e": 3,
+            6.7: 5,  # 6.7 is not converted to string, but when the entire dict will be logged mlflow will take care of the conversion
+        },
+    }

--- a/tests/framework/hooks/test_utils.py
+++ b/tests/framework/hooks/test_utils.py
@@ -64,3 +64,15 @@ def test_flatten_dict_with_float_keys():
             6.7: 5,  # 6.7 is not converted to string, but when the entire dict will be logged mlflow will take care of the conversion
         },
     }
+
+
+def test_flatten_dict_with_used_defined_sep():
+    d = dict(a=1, b=dict(c=1, d=dict(e=3, f=dict(g=4, h=5))))
+
+    assert _flatten_dict(d=d, recursive=True, sep="_") == {
+        "a": 1,
+        "b_c": 1,
+        "b_d_e": 3,
+        "b_d_f_g": 4,
+        "b_d_f_h": 5,
+    }


### PR DESCRIPTION
## Description
 Close #224 

## Development notes
- Update the ``flatten_dict`` function to avoid an error when dictionnary keys are integer (concatenation with a string raise a TypeError)

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
