### PR TITLE
Fix typo for new MetricDataSet and eval_rst rendering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,3 @@ jobs:
         file: ./coverage.xml
         env_vars: OS,PYTHON
         fail_ci_if_error: true
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        config-file: 'mlc_config.json'

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 **Code health**
 
 ----------------------------------------------------------
-| Branch | Tests | Coverage | Documentation | Deployment | Activity |
-|--------|-------|----------|---------------|------------|------------|
-| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/)|[![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish)|[![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.7.3)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.7.3...master)|
+| Branch | Tests | Coverage | Links | Documentation | Deployment | Activity |
+|--------|-------|----------|-------|---------------|------------|----------|
+| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master)|[![links](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/check-links/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Acheck-links+branch%3Amaster)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/)|[![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish)|[![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.7.3)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.7.3...master)|
 
 # What is kedro-mlflow?
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 
+from recommonmark.transform import AutoStructify
+
 # -- Project information -----------------------------------------------------
 from kedro_mlflow import __version__ as km_version
 
@@ -66,3 +68,9 @@ html_static_path = ["_static"]
 # useful to create dropdown with the name of the directory as the section name
 # see https://stackoverflow.com/questions/36925871/toctree-nested-drop-down:
 html_theme_options = {"collapse_navigation": False}
+
+
+def setup(app):
+    # enable rendering RST tables in Markdown
+    app.add_config_value("recommonmark_config", {"enable_eval_rst": True}, True)
+    app.add_transform(AutoStructify)

--- a/docs/source/04_experimentation_tracking/02_version_parameters.md
+++ b/docs/source/04_experimentation_tracking/02_version_parameters.md
@@ -2,7 +2,7 @@
 
 ## Automatic parameters versioning
 
-Parameters versioning is automatic when the ``MlflowNodeHook`` is added to [the hook list of the ``ProjectContext``](../02_installation/02_setup.md#declaring-kedro-mlflow-hooks). In ``kedro-mlflow==0.7.3``, the `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```Dict`` parameter](../07_python_objects/02_Hooks.md).
+Parameters versioning is automatic when the ``MlflowNodeHook`` is added to [the hook list of the ``ProjectContext``](../02_installation/02_setup.html#declaring-kedro-mlflow-hooks). In ``kedro-mlflow==0.7.3``, the `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```Dict`` parameter](../07_python_objects/02_Hooks.md).
 
 You **do not need any additional configuration** to benefit from parameters versioning.
 

--- a/docs/source/04_experimentation_tracking/05_version_metrics.md
+++ b/docs/source/04_experimentation_tracking/05_version_metrics.md
@@ -6,9 +6,10 @@ MLflow defines a metric as "a (key, value) pair, where the value is numeric". Ea
 
 ## How to version metrics in a kedro project?
 
-`kedro-mlflow` introduces 2 new ``AbstractDataSet``:
+`kedro-mlflow` introduces 3 ``AbstractDataSet`` to manage metrics:
 - ``MlflowMetricDataSet`` which can log a float as a metric
-- ``MlflowMetricsDataSet``. The first one It is a wrapper around a dictionary with metrics which is returned by node and log metrics in MLflow.
+- ``MlflowMetricHistoryDataSet`` which can log the evolution over time of a given metric, e.g. a list or a dict of float.
+- ``MlflowMetricsDataSet`` (**DEPRECATED**). It is a wrapper around a dictionary with metrics which is returned by node and log metrics in MLflow.
 
 ### Saving a single float as a metric with ``MlflowMetricDataSet``
 
@@ -24,7 +25,9 @@ with mlflow.start_run():
     metric_ds.save(0.3) # create a "my_metric=0.3" value in the "metric" field in mlflow UI
 ```
 
-**Beware: Unlike mlflow default behaviour, if there is no active run, no run is created.**
+```eval_rst
+.. note:: Beware: Unlike mlflow default behaviour, if there is no active run, no run is created.
+```
 
 - You can also specify a ``run_id`` instead of logging in the active run:
 
@@ -135,7 +138,7 @@ my_model_metric:
 ### Saving several metrics with their entire history with ``MlflowMetricsDataSet``
 
 ```eval_rst
-.. warning:: This class is deprecated and will be removed soon. Use MlflowMetricDataSet or MlflowMetricHistoryDataSet instead.
+.. warning:: This class is deprecated and will be removed soon. Use ``MlflowMetricDataSet`` or ``MlflowMetricHistoryDataSet`` instead.
 ```
 
 

--- a/docs/source/07_python_objects/01_DataSets.md
+++ b/docs/source/07_python_objects/01_DataSets.md
@@ -39,6 +39,17 @@ csv_dataset = MlflowArtifactDataSet(data_set={"type": CSVDataSet,
 csv_dataset.save(data=pd.DataFrame({"a":[1,2], "b": [3,4]}))
 ```
 
+## Metrics `DataSets`
+
+### ``MlflowMetricDataSet``
+
+[The ``MlflowMetricDataSet`` is documented here](../04_experimentation_tracking/05_version_metrics.html#saving-a-single-float-as-a-metric-with-mlflowmetricdataset).
+
+### ``MlflowMetricHistoryDataSet``
+
+[The ``MlflowMetricHistoryDataSet`` is documented here](../04_experimentation_tracking/05_version_metrics.html#saving-the-evolution-of-a-metric-during-training-with-mlflowmetrichistorydataset).
+
+
 ## Models `DataSets`
 
 ### ``MlflowModelLoggerDataSet``


### PR DESCRIPTION
## Description

Fix typo in documentation for the new AbstractMetricDataSet + render ``eval_rst`` block with Autostructify in sphinx

## Development notes

NA

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- N/A Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- N/A Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
