### PR TITLE
Config/refactor pydantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Changed
 
--   :recycle: ``KedroMlflowConfig`` was refactored with pydantic for improved type checking when loading configuration, overall robustness and autocompletion. Its keys have changed, but it is not considered as a user facing changes since the public function ``get_mlflow_config()`` and ``KedroMlflowConfig().setup()`` are not modified.
+- :recycle: ``KedroMlflowConfig`` was refactored with pydantic for improved type checking when loading configuration, overall robustness and autocompletion. Its keys have changed, but it is not considered as a user facing changes since the public function ``get_mlflow_config()`` and ``KedroMlflowConfig().setup()`` are not modified.
+
+- :wastebasket: The ``kedro.framework.context`` folder is moved to ``kedro.config`` for consistency with the Kedro repo structure: ``get_mlflow_config`` import must change from `from kedro_mlflow.framework.context import get_mlflow_config` to `from kedro_mlflow.config import get_mlflow_config`.
 
 ## [0.7.4] - 2021-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+-   :recycle: ``KedroMlflowConfig`` was refactored with pydantic for improved type checking when loading configuration, overall robustness and autocompletion. Its keys have changed, but it is not considered as a user facing changes since the public function ``get_mlflow_config()`` and ``KedroMlflowConfig().setup()`` are not modified.
+
 ## [0.7.4] - 2021-08-30
 
 ### Added

--- a/docs/source/02_installation/03_migration_guide.md
+++ b/docs/source/02_installation/03_migration_guide.md
@@ -16,7 +16,7 @@ There are no breaking change in this patch release except if you retrieve the ml
 
 ```python
 from kedro.framework.context import load_context
-from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.config import get_mlflow_config
 
 context=load_context(".")
 mlflow_config=get_mlflow_config(context)

--- a/docs/source/04_experimentation_tracking/02_version_parameters.md
+++ b/docs/source/04_experimentation_tracking/02_version_parameters.md
@@ -2,7 +2,7 @@
 
 ## Automatic parameters versioning
 
-Parameters versioning is automatic when the ``MlflowNodeHook`` is added to [the hook list of the ``ProjectContext``](../02_installation/02_setup.html#declaring-kedro-mlflow-hooks). In ``kedro-mlflow==0.7.4``, the `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```Dict`` parameter](../07_python_objects/02_Hooks.md).
+Parameters versioning is automatic when the ``MlflowNodeHook`` is added to [the hook list of the ``ProjectContext``](https://kedro-mlflow.readthedocs.io/en/latest/source/02_installation/02_setup.html#declaring-kedro-mlflow-hooks). In ``kedro-mlflow==0.7.4``, the `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```Dict`` parameter](../07_python_objects/02_Hooks.md).
 
 You **do not need any additional configuration** to benefit from parameters versioning.
 

--- a/docs/source/07_python_objects/01_DataSets.md
+++ b/docs/source/07_python_objects/01_DataSets.md
@@ -43,11 +43,11 @@ csv_dataset.save(data=pd.DataFrame({"a":[1,2], "b": [3,4]}))
 
 ### ``MlflowMetricDataSet``
 
-[The ``MlflowMetricDataSet`` is documented here](../04_experimentation_tracking/05_version_metrics.html#saving-a-single-float-as-a-metric-with-mlflowmetricdataset).
+[The ``MlflowMetricDataSet`` is documented here](https://kedro-mlflow.readthedocs.io/en/latest/source/04_experimentation_tracking/05_version_metrics.html#saving-a-single-float-as-a-metric-with-mlflowmetricdataset).
 
 ### ``MlflowMetricHistoryDataSet``
 
-[The ``MlflowMetricHistoryDataSet`` is documented here](../04_experimentation_tracking/05_version_metrics.html#saving-the-evolution-of-a-metric-during-training-with-mlflowmetrichistorydataset).
+[The ``MlflowMetricHistoryDataSet`` is documented here](https://kedro-mlflow.readthedocs.io/en/latest/source/04_experimentation_tracking/05_version_metrics.html#saving-a-single-float-as-a-metric-with-mlflowmetricdataset).
 
 
 ## Models `DataSets`

--- a/kedro_mlflow/config/__init__.py
+++ b/kedro_mlflow/config/__init__.py
@@ -1,0 +1,4 @@
+"""kedro-mlflow context imports
+"""
+
+from .kedro_mlflow_config import get_mlflow_config

--- a/kedro_mlflow/config/kedro_mlflow_config.py
+++ b/kedro_mlflow/config/kedro_mlflow_config.py
@@ -1,0 +1,197 @@
+import os
+from pathlib import Path, PurePath
+from typing import List, Optional
+
+import mlflow
+from kedro.config import MissingConfigException
+from kedro.framework.session import KedroSession, get_current_session
+from kedro.framework.startup import _is_project
+from mlflow.entities import Experiment
+from mlflow.tracking.client import MlflowClient
+from pydantic import BaseModel, PrivateAttr, StrictBool, validator
+from typing_extensions import Literal
+
+
+class DisableTrackingOptions(BaseModel):
+    # mutable default is ok for pydantic : https://stackoverflow.com/questions/63793662/how-to-give-a-pydantic-list-field-a-default-value
+    pipelines: List[str] = []
+
+    class Config:
+        extra = "forbid"
+
+
+class ExperimentOptions(BaseModel):
+    name: str = "Default"
+    create: StrictBool = True
+
+    class Config:
+        extra = "forbid"
+
+
+class RunOptions(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    nested: StrictBool = True
+
+    class Config:
+        extra = "forbid"
+
+
+class UiOptions(BaseModel):
+    port: str = "5000"
+    host: str = "127.0.0.1"
+
+    class Config:
+        extra = "forbid"
+
+
+class NodeHookOptions(BaseModel):
+    flatten_dict_params: StrictBool = False
+    recursive: StrictBool = True
+    sep: str = "."
+    long_parameters_strategy: Literal["fail", "truncate", "tag"] = "fail"
+
+    class Config:
+        extra = "forbid"
+
+
+class HookOptions(BaseModel):
+    node: NodeHookOptions = NodeHookOptions()
+
+    class Config:
+        extra = "forbid"
+
+
+class KedroMlflowConfig(BaseModel):
+    project_path: Path  # if str, will be converted
+    mlflow_tracking_uri: str = "mlruns"
+    credentials: Optional[str]
+    disable_tracking: DisableTrackingOptions = DisableTrackingOptions()
+    experiment: ExperimentOptions = ExperimentOptions()
+    run: RunOptions = RunOptions()
+    ui: UiOptions = UiOptions()
+    hooks: HookOptions = HookOptions()
+    _mlflow_client: MlflowClient = PrivateAttr()
+    _experiment: Experiment = PrivateAttr()
+    # do not create _experiment immediately to avoid creating
+    # a database connection when creating the object
+    # it will be instantiated on setup() call
+
+    class Config:
+        # force triggering type control when setting value instead of init
+        validate_assignment = True
+        # raise an error if an unknown key is passed to the constructor
+        extra = "forbid"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # init after validating the uri, else mlflow creates a mlruns folder at the root
+        self._mlflow_client = MlflowClient(tracking_uri=self.mlflow_tracking_uri)
+
+    def setup(self, session: KedroSession = None):
+        """Setup all the mlflow configuration"""
+
+        self._export_credentials(session)
+
+        # we set the configuration now: it takes priority
+        # if it has already be set in export_credentials
+        mlflow.set_tracking_uri(self.mlflow_tracking_uri)
+
+        self._get_or_create_experiment()
+
+    def _export_credentials(self, session: KedroSession = None):
+        session = session or get_current_session()
+        context = session.load_context()
+        conf_creds = context._get_config_credentials()
+        mlflow_creds = conf_creds.get(self.credentials, {})
+        for key, value in mlflow_creds.items():
+            os.environ[key] = value
+
+    def _get_or_create_experiment(self):
+        """Best effort to get the experiment associated
+        to the configuration
+
+        Returns:
+            mlflow.entities.Experiment -- [description]
+        """
+
+        # retrieve the experiment
+        self._experiment = self._mlflow_client.get_experiment_by_name(
+            name=self.experiment.name
+        )
+
+        # Deal with two side case when retrieving the experiment
+        if self.experiment.create:
+            if self._experiment is None:
+                # case 1 : the experiment does not exist, it must be created manually
+                experiment_id = self._mlflow_client.create_experiment(
+                    name=self.experiment.name
+                )
+                self._experiment = self._mlflow_client.get_experiment(
+                    experiment_id=experiment_id
+                )
+            elif self._experiment.lifecycle_stage == "deleted":
+                # case 2: the experiment was created, then deleted : we have to restore it manually
+                self._mlflow_client.restore_experiment(self._experiment.experiment_id)
+
+    @validator("project_path")
+    def _is_kedro_project(cls, folder_path):
+        if not _is_project(folder_path):
+            raise KedroMlflowConfigError(
+                f"'project_path' = '{folder_path}' is not the root of kedro project"
+            )
+        return folder_path
+
+    # pre=make a conversion before it is set
+    # always=even for default value
+    # values enable access to the other field, see https://pydantic-docs.helpmanual.io/usage/validators/
+    @validator("mlflow_tracking_uri", pre=True, always=True)
+    def _validate_uri(cls, uri, values):
+        """Format the uri provided to match mlflow expectations.
+
+        Arguments:
+            uri {Union[None, str]} -- A valid filepath for mlflow uri
+
+        Returns:
+            str -- A valid mlflow_tracking_uri
+        """
+
+        # if no tracking uri is provided, we register the runs locally at the root of the project
+        pathlib_uri = PurePath(uri)
+
+        from urllib.parse import urlparse
+
+        if pathlib_uri.is_absolute():
+            valid_uri = pathlib_uri.as_uri()
+        else:
+            parsed = urlparse(uri)
+            if parsed.scheme == "":
+                # if it is a local relative path, make it absolute
+                # .resolve() does not work well on windows
+                # .absolute is undocumented and have known bugs
+                # Path.cwd() / uri is the recommend way by core developpers.
+                # See : https://discuss.python.org/t/pathlib-absolute-vs-resolve/2573/6
+                valid_uri = (values["project_path"] / uri).as_uri()
+            else:
+                # else assume it is an uri
+                valid_uri = uri
+
+        return valid_uri
+
+
+class KedroMlflowConfigError(Exception):
+    """Error occurred when loading the configuration"""
+
+
+def get_mlflow_config(session: Optional[KedroSession] = None):
+    session = session or get_current_session()
+    context = session.load_context()
+    try:
+        conf_mlflow_yml = context.config_loader.get("mlflow*", "mlflow*/**")
+    except MissingConfigException:
+        raise KedroMlflowConfigError(
+            "No 'mlflow.yml' config file found in environment. Use ``kedro mlflow init`` command in CLI to create a default config file."
+        )
+    conf_mlflow_yml["project_path"] = context.project_path
+    mlflow_config = KedroMlflowConfig.parse_obj(conf_mlflow_yml)
+    return mlflow_config

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -5,8 +5,8 @@ import click
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import _is_project, bootstrap_project
 
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
-from kedro_mlflow.framework.context import get_mlflow_config
 
 TEMPLATE_FOLDER_PATH = Path(__file__).parent.parent.parent / "template" / "project"
 
@@ -149,8 +149,8 @@ def ui(env, port, host):
     ):
 
         mlflow_conf = get_mlflow_config()
-        host = host or mlflow_conf.ui_opts.get("host")
-        port = port or mlflow_conf.ui_opts.get("port")
+        host = host or mlflow_conf.ui.host
+        port = port or mlflow_conf.ui.port
 
         # call mlflow ui with specific options
         # TODO : add more options for ui

--- a/kedro_mlflow/framework/context/mlflow_context.py
+++ b/kedro_mlflow/framework/context/mlflow_context.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
+from deprecation import deprecated
 from kedro.config import MissingConfigException
 from kedro.framework.session import KedroSession, get_current_session
 
+from kedro_mlflow import __version__
 from kedro_mlflow.framework.context.config import (
     KedroMlflowConfig,
     KedroMlflowConfigError,
@@ -12,6 +14,12 @@ from kedro_mlflow.framework.context.config import (
 # this could be a read-only property in the context
 # with a @property decorator
 # but for consistency with hook system, it is an external function
+@deprecated(
+    deprecated_in="0.7.5",
+    removed_in="0.8.0",
+    current_version=__version__,
+    details="This function was moved to 'kedro_mlflow.config' folder. Use 'from kedro_mlflow.config import get_mlflow_config' instead of 'from kedro_mlflow.framework.context import get_mlflow_config'",
+)
 def get_mlflow_config(session: Optional[KedroSession] = None):
     session = session or get_current_session()
     context = session.load_context()

--- a/kedro_mlflow/framework/hooks/node_hook.py
+++ b/kedro_mlflow/framework/hooks/node_hook.py
@@ -8,7 +8,7 @@ from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 from mlflow.utils.validation import MAX_PARAM_VAL_LENGTH
 
-from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.hooks.utils import _assert_mlflow_enabled, _flatten_dict
 
 
@@ -53,14 +53,14 @@ class MlflowNodeHook:
         self._is_mlflow_enabled = _assert_mlflow_enabled(run_params["pipeline_name"])
 
         if self._is_mlflow_enabled:
-            config = get_mlflow_config()
+            mlflow_config = get_mlflow_config()
 
-            self.flatten = config.node_hook_opts["flatten_dict_params"]
-            self.recursive = config.node_hook_opts["recursive"]
-            self.sep = config.node_hook_opts["sep"]
-            self.long_parameters_strategy = config.node_hook_opts[
-                "long_parameters_strategy"
-            ]
+            self.flatten = mlflow_config.hooks.node.flatten_dict_params
+            self.recursive = mlflow_config.hooks.node.recursive
+            self.sep = mlflow_config.hooks.node.sep
+            self.long_parameters_strategy = (
+                mlflow_config.hooks.node.long_parameters_strategy
+            )
 
     @hook_impl
     def before_node_run(

--- a/kedro_mlflow/framework/hooks/pipeline_hook.py
+++ b/kedro_mlflow/framework/hooks/pipeline_hook.py
@@ -13,7 +13,7 @@ from kedro.versioning.journal import _git_sha
 from mlflow.entities import RunStatus
 from mlflow.models import infer_signature
 
-from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.hooks.utils import _assert_mlflow_enabled
 from kedro_mlflow.io.catalog.switch_catalog_logging import switch_catalog_logging
 from kedro_mlflow.io.metrics import (
@@ -111,19 +111,16 @@ class MlflowPipelineHook:
         self._is_mlflow_enabled = _assert_mlflow_enabled(run_params["pipeline_name"])
 
         if self._is_mlflow_enabled:
-            mlflow_conf = get_mlflow_config()
-            mlflow_conf.setup()
+            mlflow_config = get_mlflow_config()
+            mlflow_config.setup()
 
-            run_name = (
-                mlflow_conf.run_opts["name"]
-                if mlflow_conf.run_opts["name"] is not None
-                else run_params["pipeline_name"]
-            )
+            run_name = mlflow_config.run.name or run_params["pipeline_name"]
+
             mlflow.start_run(
-                run_id=mlflow_conf.run_opts["id"],
-                experiment_id=mlflow_conf.experiment.experiment_id,
+                run_id=mlflow_config.run.id,
+                experiment_id=mlflow_config._experiment.experiment_id,
                 run_name=run_name,
-                nested=mlflow_conf.run_opts["nested"],
+                nested=mlflow_config.run.nested,
             )
             # Set tags only for run parameters that have values.
             mlflow.set_tags({k: v for k, v in run_params.items() if v})

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from kedro_mlflow.framework.context.mlflow_context import get_mlflow_config
+from kedro_mlflow.config.kedro_mlflow_config import get_mlflow_config
 
 
 def _assert_mlflow_enabled(pipeline_name: str) -> bool:
@@ -9,7 +9,7 @@ def _assert_mlflow_enabled(pipeline_name: str) -> bool:
     # TODO: we may want to enable to filter on tags
     # but we need to deal with the case when several tags are passed
     # what to do if 1 out of 2 is in the list?
-    disabled_pipelines = mlflow_config.disable_tracking_opts.get("pipelines") or []
+    disabled_pipelines = mlflow_config.disable_tracking.pipelines
     if pipeline_name in disabled_pipelines:
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 kedro>=0.17.1, <0.18.0
 mlflow>=1.0.0, <2.0.0
 deprecation==2.1.0
+pydantic>=1.0.0, <2.0.0

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -1,0 +1,126 @@
+import pytest
+import yaml
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import bootstrap_project
+
+from kedro_mlflow.config import get_mlflow_config
+from kedro_mlflow.config.kedro_mlflow_config import KedroMlflowConfigError
+
+
+def _write_yaml(filepath, config):
+    yaml_str = yaml.dump(config)
+    filepath.write_text(yaml_str)
+
+
+# TODO : reenable this test which is currently failing beacause kedro "import settings"
+# is completetly messing up because we have several projects
+# and the first import wins
+
+
+def test_get_mlflow_config(kedro_project):
+    # kedro_project is a pytest.fixture in conftest
+
+    _write_yaml(
+        kedro_project / "conf" / "local" / "mlflow.yml",
+        dict(
+            mlflow_tracking_uri="mlruns",
+            credentials=None,
+            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
+            experiment=dict(name="fake_package", create=True),
+            run=dict(id="123456789", name="my_run", nested=True),
+            ui=dict(port="5151", host="localhost"),
+            hooks=dict(
+                node=dict(
+                    flatten_dict_params=True,
+                    recursive=False,
+                    sep="-",
+                    long_parameters_strategy="truncate",
+                )
+            ),
+        ),
+    )
+    expected = {
+        "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
+        "credentials": None,
+        "disable_tracking": {"pipelines": ["my_disabled_pipeline"]},
+        "experiment": {"name": "fake_package", "create": True},
+        "run": {"id": "123456789", "name": "my_run", "nested": True},
+        "ui": {"port": "5151", "host": "localhost"},
+        "hooks": {
+            "node": {
+                "flatten_dict_params": True,
+                "recursive": False,
+                "sep": "-",
+                "long_parameters_strategy": "truncate",
+            }
+        },
+    }
+
+    bootstrap_project(kedro_project)
+    with KedroSession.create(project_path=kedro_project):
+        assert get_mlflow_config().dict(exclude={"project_path"}) == expected
+
+
+def test_get_mlflow_config_in_uninitialized_project(kedro_project):
+    # config_with_base_mlflow_conf is a pytest.fixture in conftest
+    with pytest.raises(
+        KedroMlflowConfigError, match="No 'mlflow.yml' config file found in environment"
+    ):
+        bootstrap_project(kedro_project)
+        with KedroSession.create(project_path=kedro_project):
+            get_mlflow_config()
+
+
+# TODO : reenable this test which is currently failing beacause kedro "import settings"
+# is completetly messing up beacause we have several projects
+# and the first import wins
+
+
+def test_mlflow_config_with_templated_config_loader(
+    kedro_project_with_tcl,
+):
+
+    _write_yaml(
+        kedro_project_with_tcl / "conf" / "local" / "mlflow.yml",
+        dict(
+            mlflow_tracking_uri="${mlflow_tracking_uri}",
+            credentials=None,
+            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
+            experiment=dict(name="fake_package", create=True),
+            run=dict(id="123456789", name="my_run", nested=True),
+            ui=dict(port="5151", host="localhost"),
+            hooks=dict(
+                node=dict(
+                    flatten_dict_params=True,
+                    recursive=False,
+                    sep="-",
+                    long_parameters_strategy="truncate",
+                )
+            ),
+        ),
+    )
+
+    _write_yaml(
+        kedro_project_with_tcl / "conf" / "local" / "globals.yml",
+        dict(mlflow_tracking_uri="dynamic_mlruns"),
+    )
+
+    expected = {
+        "mlflow_tracking_uri": (kedro_project_with_tcl / "dynamic_mlruns").as_uri(),
+        "credentials": None,
+        "disable_tracking": {"pipelines": ["my_disabled_pipeline"]},
+        "experiment": {"name": "fake_package", "create": True},
+        "run": {"id": "123456789", "name": "my_run", "nested": True},
+        "ui": {"port": "5151", "host": "localhost"},
+        "hooks": {
+            "node": {
+                "flatten_dict_params": True,
+                "recursive": False,
+                "sep": "-",
+                "long_parameters_strategy": "truncate",
+            }
+        },
+    }
+    bootstrap_project(kedro_project_with_tcl)
+    with KedroSession.create(project_path=kedro_project_with_tcl):
+        assert get_mlflow_config().dict(exclude={"project_path"}) == expected

--- a/tests/config/test_kedro_mlflow_config.py
+++ b/tests/config/test_kedro_mlflow_config.py
@@ -1,0 +1,190 @@
+import os
+
+import mlflow
+import pytest
+import yaml
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import bootstrap_project
+from mlflow.tracking import MlflowClient
+
+from kedro_mlflow.config.kedro_mlflow_config import (
+    DisableTrackingOptions,
+    ExperimentOptions,
+    HookOptions,
+    KedroMlflowConfig,
+    KedroMlflowConfigError,
+    RunOptions,
+    UiOptions,
+)
+
+
+def test_kedro_mlflow_config_init_wrong_path(tmp_path):
+    # create a ".kedro.yml" file to identify "tmp_path" as the root of a kedro project
+    with pytest.raises(
+        KedroMlflowConfigError, match="is not the root of kedro project"
+    ):
+        KedroMlflowConfig(project_path=tmp_path)
+
+
+def test_kedro_mlflow_config_init(kedro_project_with_mlflow_conf):
+    # kedro_project_with_mlflow_conf is a global fixture in conftest
+
+    config = KedroMlflowConfig(project_path=kedro_project_with_mlflow_conf)
+    assert config.dict(exclude={"project_path"}) == dict(
+        mlflow_tracking_uri=(kedro_project_with_mlflow_conf / "mlruns").as_uri(),
+        credentials=None,
+        disable_tracking=DisableTrackingOptions().dict(),
+        experiment=ExperimentOptions().dict(),
+        run=RunOptions().dict(),
+        ui=UiOptions().dict(),
+        hooks=HookOptions().dict(),
+    )
+
+
+def test_kedro_mlflow_config_new_experiment_does_not_exists(
+    kedro_project_with_mlflow_conf,
+):
+
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf,
+        mlflow_tracking_uri="mlruns",
+        experiment=dict(name="exp1"),
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+
+    assert "exp1" in [exp.name for exp in config._mlflow_client.list_experiments()]
+
+
+def test_kedro_mlflow_config_experiment_exists(mocker, kedro_project_with_mlflow_conf):
+
+    # create an experiment with the same name
+    mlflow_tracking_uri = (
+        kedro_project_with_mlflow_conf / "conf" / "local" / "mlruns"
+    ).as_uri()
+    MlflowClient(mlflow_tracking_uri).create_experiment("exp1")
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf,
+        mlflow_tracking_uri="mlruns",
+        experiment=dict(name="exp1"),
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+    assert "exp1" in [exp.name for exp in config._mlflow_client.list_experiments()]
+
+
+def test_kedro_mlflow_config_experiment_was_deleted(kedro_project_with_mlflow_conf):
+
+    # create an experiment with the same name and then delete it
+    mlflow_tracking_uri = (kedro_project_with_mlflow_conf / "mlruns").as_uri()
+    mlflow_client = MlflowClient(mlflow_tracking_uri)
+    mlflow_client.create_experiment("exp1")
+    mlflow_client.delete_experiment(
+        mlflow_client.get_experiment_by_name("exp1").experiment_id
+    )
+
+    # the config must restore properly the experiment
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf,
+        mlflow_tracking_uri="mlruns",
+        experiment=dict(name="exp1"),
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+
+    assert "exp1" in [exp.name for exp in config._mlflow_client.list_experiments()]
+
+
+def test_kedro_mlflow_config_setup_set_tracking_uri(kedro_project_with_mlflow_conf):
+
+    # create an experiment with the same name and then delete it
+    mlflow_tracking_uri = (kedro_project_with_mlflow_conf / "awesome_tracking").as_uri()
+
+    # the config must restore properly the experiment
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf,
+        mlflow_tracking_uri="awesome_tracking",
+        experiment=dict(name="exp1"),
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+
+    assert mlflow.get_tracking_uri() == mlflow_tracking_uri
+
+
+def test_kedro_mlflow_config_setup_export_credentials(kedro_project_with_mlflow_conf):
+
+    (kedro_project_with_mlflow_conf / "conf/base/credentials.yml").write_text(
+        yaml.dump(dict(my_mlflow_creds=dict(fake_mlflow_cred="my_fake_cred")))
+    )
+
+    # the config must restore properly the experiment
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf, credentials="my_mlflow_creds"
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+
+    assert os.environ["fake_mlflow_cred"] == "my_fake_cred"
+
+
+def test_kedro_mlflow_config_setup_tracking_priority(kedro_project_with_mlflow_conf):
+    """Test if the mlflow_tracking uri set is the one of mlflow.yml
+    if it also exist in credentials.
+
+    """
+    # create a ".kedro.yml" file to identify "tmp_path" as the root of a kedro project
+
+    (kedro_project_with_mlflow_conf / "conf/base/credentials.yml").write_text(
+        yaml.dump(dict(my_mlflow_creds=dict(mlflow_tracking_uri="mlruns2")))
+    )
+
+    config = KedroMlflowConfig(
+        project_path=kedro_project_with_mlflow_conf,
+        mlflow_tracking_uri="mlruns1",
+        credentials="my_mlflow_creds",
+    )
+
+    bootstrap_project(kedro_project_with_mlflow_conf)
+    with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
+        config.setup()
+
+    assert (
+        mlflow.get_tracking_uri()
+        == (kedro_project_with_mlflow_conf / "mlruns1").as_uri()
+    )
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        (r"mlruns"),  # relative
+        (pytest.lazy_fixture("tmp_path")),  # absolute
+        (r"file:///C:/fake/path/mlruns"),  # local uri
+    ],
+)
+def test_kedro_mlflow_config_validate_uri_local(kedro_project_with_mlflow_conf, uri):
+
+    assert KedroMlflowConfig._validate_uri(
+        uri=uri, values={"project_path": kedro_project_with_mlflow_conf}
+    ).startswith(
+        r"file:///"
+    )  # relative
+
+
+def test_from_dict_to_dict_idempotent(kedro_project_with_mlflow_conf):
+    config = KedroMlflowConfig(project_path=kedro_project_with_mlflow_conf)
+    original_config_dict = config.dict()
+    # modify config
+    reloaded_config = KedroMlflowConfig.parse_obj(original_config_dict)
+    assert config == reloaded_config

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -8,10 +8,10 @@ from kedro.framework.cli.cli import info
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.cli.cli import init as cli_init
 from kedro_mlflow.framework.cli.cli import mlflow_commands as cli_mlflow
 from kedro_mlflow.framework.cli.cli import ui as cli_ui
-from kedro_mlflow.framework.context import get_mlflow_config
 
 
 def extract_cmd_from_help(msg):

--- a/tests/framework/context/test_config.py
+++ b/tests/framework/context/test_config.py
@@ -3,6 +3,7 @@ import os
 import mlflow
 import pytest
 import yaml
+from deprecation import fail_if_not_removed
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 from mlflow.tracking import MlflowClient
@@ -14,6 +15,7 @@ from kedro_mlflow.framework.context.config import (
 )
 
 
+@fail_if_not_removed
 def test_validate_opts_invalid_option():
     d1 = dict(c=3)
     d2 = dict(a=1, b=2)
@@ -24,6 +26,7 @@ def test_validate_opts_invalid_option():
         _validate_opts(d1, d2)
 
 
+@fail_if_not_removed
 def test_validate_opts_missing_options():
     d1 = dict(a=4)
     d2 = dict(a=1, b=2)
@@ -33,6 +36,7 @@ def test_validate_opts_missing_options():
     assert d2 == dict(a=1, b=2)
 
 
+@fail_if_not_removed
 def test_validate_opts_no_options():
     d1 = None
     d2 = dict(a=1, b=2)
@@ -42,6 +46,7 @@ def test_validate_opts_no_options():
     assert d2 == dict(a=1, b=2)
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_init_wrong_path(tmp_path):
     # create a ".kedro.yml" file to identify "tmp_path" as the root of a kedro project
     with pytest.raises(
@@ -50,6 +55,7 @@ def test_kedro_mlflow_config_init_wrong_path(tmp_path):
         KedroMlflowConfig(project_path=tmp_path)
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_init(kedro_project_with_mlflow_conf):
     # kedro_project_with_mlflow_conf is a global fixture in conftest
 
@@ -65,6 +71,7 @@ def test_kedro_mlflow_config_init(kedro_project_with_mlflow_conf):
     )
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_bad_long_parameters_strategy(
     kedro_project_with_mlflow_conf,
 ):
@@ -78,6 +85,7 @@ def test_kedro_mlflow_config_bad_long_parameters_strategy(
         )
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_new_experiment_does_not_exists(
     kedro_project_with_mlflow_conf,
 ):
@@ -95,6 +103,7 @@ def test_kedro_mlflow_config_new_experiment_does_not_exists(
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_experiment_exists(mocker, kedro_project_with_mlflow_conf):
 
     # create an experiment with the same name
@@ -114,6 +123,7 @@ def test_kedro_mlflow_config_experiment_exists(mocker, kedro_project_with_mlflow
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_experiment_was_deleted(kedro_project_with_mlflow_conf):
 
     # create an experiment with the same name and then delete it
@@ -138,6 +148,7 @@ def test_kedro_mlflow_config_experiment_was_deleted(kedro_project_with_mlflow_co
     assert "exp1" in [exp.name for exp in config.mlflow_client.list_experiments()]
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_setup_set_tracking_uri(kedro_project_with_mlflow_conf):
 
     # create an experiment with the same name and then delete it
@@ -157,6 +168,7 @@ def test_kedro_mlflow_config_setup_set_tracking_uri(kedro_project_with_mlflow_co
     assert mlflow.get_tracking_uri() == mlflow_tracking_uri
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_setup_export_credentials(kedro_project_with_mlflow_conf):
 
     (kedro_project_with_mlflow_conf / "conf/base/credentials.yml").write_text(
@@ -175,6 +187,7 @@ def test_kedro_mlflow_config_setup_export_credentials(kedro_project_with_mlflow_
     assert os.environ["fake_mlflow_cred"] == "my_fake_cred"
 
 
+@fail_if_not_removed
 def test_kedro_mlflow_config_setup_tracking_priority(kedro_project_with_mlflow_conf):
     """Test if the mlflow_tracking uri set is the one of mlflow.yml
     if it also eist in credentials.
@@ -205,6 +218,7 @@ def test_kedro_mlflow_config_setup_tracking_priority(kedro_project_with_mlflow_c
     )
 
 
+@fail_if_not_removed
 @pytest.mark.parametrize(
     "uri",
     [
@@ -226,6 +240,7 @@ def test_kedro_mlflow_config_validate_uri_local(
     assert config._validate_uri(uri=uri).startswith(r"file:///")  # relative
 
 
+@fail_if_not_removed
 def test_from_dict_to_dict_idempotent(mocker, kedro_project_with_mlflow_conf):
     mocker.patch("mlflow.tracking.MlflowClient", return_value=None)
     mocker.patch(

--- a/tests/framework/hooks/test_all_hooks.py
+++ b/tests/framework/hooks/test_all_hooks.py
@@ -20,7 +20,7 @@ from kedro.pipeline import Pipeline, node
 from kedro.versioning import Journal
 from mlflow.tracking import MlflowClient
 
-from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.hooks import MlflowNodeHook, MlflowPipelineHook
 
 MOCK_PACKAGE_NAME = "mock_package_name"

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -125,9 +125,9 @@ def test_node_hook_logging(
 
     # config = KedroMlflowConfig(
     #     project_path=tmp_path,
-    #     node_hook_opts={"flatten_dict_params": flatten_dict_params, "sep": "-"},
+    #     hooks={"node":{"flatten_dict_params": flatten_dict_params, "sep": "-"}},
     # )
-    # # the function is imported inside the other file antd this is the file to patch
+    # # the function is imported inside the other file ant this is the file to patch
     # # see https://stackoverflow.com/questions/30987973/python-mock-patch-doesnt-work-as-expected-for-public-method
     # mocker.patch(
     #     "kedro_mlflow.framework.hooks.node_hook.get_mlflow_config", return_value=config

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -19,7 +19,7 @@ from mlflow.entities import RunStatus
 from mlflow.models import infer_signature
 from mlflow.tracking import MlflowClient
 
-from kedro_mlflow.framework.context import get_mlflow_config
+from kedro_mlflow.config import get_mlflow_config
 from kedro_mlflow.framework.hooks.pipeline_hook import (
     MlflowPipelineHook,
     _format_conda_env,

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -1,9 +1,9 @@
 import pytest
 import yaml
 
+from kedro_mlflow.config.kedro_mlflow_config import ExperimentOptions, KedroMlflowConfig
 from kedro_mlflow.framework.cli.cli import TEMPLATE_FOLDER_PATH
 from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
-from kedro_mlflow.framework.context.config import KedroMlflowConfig
 
 
 @pytest.fixture
@@ -24,17 +24,16 @@ def template_mlflowyml(tmp_path):
 
 
 def test_mlflow_yml_rendering(template_mlflowyml):
+
     # the mlflow yml file must be consistent with the default in KedroMlflowConfig for readibility
     with open(template_mlflowyml, "r") as file_handler:
         mlflow_config = yaml.load(file_handler)
-    expected_config = dict(
-        mlflow_tracking_uri="mlruns",
-        credentials=None,
-        disable_tracking=KedroMlflowConfig.DISABLE_TRACKING_OPTS,
-        experiment=KedroMlflowConfig.EXPERIMENT_OPTS,
-        ui=KedroMlflowConfig.UI_OPTS,
-        run=KedroMlflowConfig.RUN_OPTS,
-        hooks=dict(node=KedroMlflowConfig.NODE_HOOK_OPTS),
+
+    # note: Using Pydantic model Construct method skip all validations
+    # and here we do not want to check the path
+    expected_config = KedroMlflowConfig.construct(
+        project_path="fake/path",
+        experiment=ExperimentOptions(name="fake_project"),  # check for proper rendering
     )
-    expected_config["experiment"]["name"] = "fake_project"  # check for proper rendering
-    assert mlflow_config == expected_config
+
+    assert mlflow_config == expected_config.dict(exclude={"project_path"})


### PR DESCRIPTION
## Description

The goal is to refactor configuration with ``pydantic`` as a pre requisite for #77.

## Development notes

- Refactor KedroMlflowConfig class to replace all dict options by ``pydantic`` models.

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
