### PR TITLE
:memo: Use sphinx to automatically document the API with docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 exclude: ^kedro_mlflow/template/project/run.py$
 repos:
     - repo: https://github.com/psf/black
-      rev: 21.7b0
+      rev: 21.9b0
       hooks:
           - id: black
             language_version: python3.7
     - repo: https://github.com/timothycrosley/isort
-      rev: 5.9.2
+      rev: 5.9.3
       hooks:
           - id: isort
     - repo: https://gitlab.com/pycqa/flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- :sparkles: Add support for notebook use . When a notebook is opened via a kedro command (e.g. `kedro jupyter notebook`), you can call the `%reload_kedro_mlflow` line magic to setup mlflow configuration automatically. A ``mlflow_client`` to the database is also created available as a global variable ([#124](https://github.com/Galileo-Galilei/kedro-mlflow/issues/124)).
+- :sparkles: Add support for notebook use. When a notebook is opened via a kedro command (e.g. `kedro jupyter notebook`), you can call the `%reload_kedro_mlflow` line magic to setup mlflow configuration automatically. A ``mlflow_client`` to the database is also created available as a global variable ([#124](https://github.com/Galileo-Galilei/kedro-mlflow/issues/124)).
+- :memo: Add automatic API documentation through docstrings for better consistency between code and docs ([#110](https://github.com/Galileo-Galilei/kedro-mlflow/issues/110)). All docstrings are not updated yet and it will be a long term work.
 
 ### Changed
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,29 @@ release = km_version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["recommonmark", "sphinx_markdown_tables"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx_click",
+    # "sphinx_autodoc_typehints",
+    # "sphinx.ext.doctest",
+    # "sphinx.ext.todo",
+    # "sphinx.ext.coverage",
+    # "sphinx.ext.mathjax",
+    # "sphinx.ext.ifconfig",
+    # "sphinx.ext.viewcode",
+    # "nbsphinx",
+    "recommonmark",
+    "sphinx_copybutton",
+    "sphinx_markdown_tables",
+]
+
+# enable autosummary plugin (table of contents for modules/classes/class
+# methods)
+autosummary_generate = True
+autosummary_generate_overwrite = False
+napoleon_include_init_with_doc = True
 
 # enable documentation in markdown
 source_suffix = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to kedro-mlflow's documentation!
 ========================================
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 6
 
    Introduction <source/01_introduction/index.rst>
    Installation <source/02_installation/index.rst>
@@ -17,6 +17,10 @@ Welcome to kedro-mlflow's documentation!
    Interactive use <source/06_interactive_use/index.rst>
    Python objects <source/07_python_objects/index.rst>
 
+.. toctree::
+   :maxdepth: 6
+
+   API documentation <source/08_API/kedro_mlflow.rst>
 
 Indices and tables
 ==================

--- a/docs/source/08_API/kedro_mlflow.config.rst
+++ b/docs/source/08_API/kedro_mlflow.config.rst
@@ -1,0 +1,7 @@
+Configuration
+====================================
+
+.. automodule:: kedro_mlflow.config.kedro_mlflow_config
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.extras.extensions.rst
+++ b/docs/source/08_API/kedro_mlflow.extras.extensions.rst
@@ -1,0 +1,7 @@
+Notebook
+======================================================
+
+.. automodule:: kedro_mlflow.extras.extensions.ipython
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.framework.cli.rst
+++ b/docs/source/08_API/kedro_mlflow.framework.cli.rst
@@ -1,0 +1,10 @@
+CLI
+====
+
+.. click:: kedro_mlflow.framework.cli.cli:init
+   :prog: init
+   :nested: full
+
+.. click:: kedro_mlflow.framework.cli.cli:ui
+   :prog: ui
+   :nested: full

--- a/docs/source/08_API/kedro_mlflow.framework.hooks.rst
+++ b/docs/source/08_API/kedro_mlflow.framework.hooks.rst
@@ -1,0 +1,18 @@
+Hooks
+======
+
+Node Hook
+-----------
+
+.. automodule:: kedro_mlflow.framework.hooks.node_hook
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Pipeline Hook
+-------------
+
+.. automodule:: kedro_mlflow.framework.hooks.pipeline_hook
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.io.rst
+++ b/docs/source/08_API/kedro_mlflow.io.rst
@@ -1,0 +1,47 @@
+Datasets
+==================================
+
+Artifact DataSet
+-----------------
+
+.. automodule:: kedro_mlflow.io.artifacts.mlflow_artifact_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Metrics DataSet
+----------------
+
+.. automodule:: kedro_mlflow.io.metrics.mlflow_metric_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: kedro_mlflow.io.metrics.mlflow_metric_history_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: kedro_mlflow.io.metrics.mlflow_metrics_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Models DataSet
+---------------
+
+.. automodule:: kedro_mlflow.io.models.mlflow_abstract_model_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: kedro_mlflow.io.models.mlflow_model_logger_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: kedro_mlflow.io.models.mlflow_model_saver_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.mlflow.rst
+++ b/docs/source/08_API/kedro_mlflow.mlflow.rst
@@ -1,0 +1,7 @@
+Custom Mlflow Models
+====================
+
+.. automodule:: kedro_mlflow.mlflow.kedro_pipeline_model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.pipeline.rst
+++ b/docs/source/08_API/kedro_mlflow.pipeline.rst
@@ -1,0 +1,12 @@
+Pipelines
+=========
+
+.. automodule:: kedro_mlflow.pipeline.pipeline_ml
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: kedro_mlflow.pipeline.pipeline_ml_factory
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/08_API/kedro_mlflow.rst
+++ b/docs/source/08_API/kedro_mlflow.rst
@@ -1,0 +1,13 @@
+kedro\_mlflow package
+=====================
+
+.. toctree::
+   :maxdepth: 6
+
+   kedro_mlflow.io
+   kedro_mlflow.framework.cli
+   kedro_mlflow.pipeline
+   kedro_mlflow.mlflow
+   kedro_mlflow.config
+   kedro_mlflow.extras.extensions
+   kedro_mlflow.framework.hooks

--- a/docs/source/08_advanced_use/01_run_with_mlproject.md
+++ b/docs/source/08_advanced_use/01_run_with_mlproject.md
@@ -1,1 +1,0 @@
-# Create an ``MLproject`` file

--- a/docs/source/08_advanced_use/02_compatbility_chart.md
+++ b/docs/source/08_advanced_use/02_compatbility_chart.md
@@ -1,1 +1,0 @@
-## Compatibility between kedro, mlflow and kedro-mlflow

--- a/docs/source/08_advanced_use/index.rst
+++ b/docs/source/08_advanced_use/index.rst
@@ -1,7 +1,0 @@
-Introduction
-============
-
-.. toctree::
-   :maxdepth: 4
-
-   Migration guide <00_migration_guide.md>

--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -9,7 +9,6 @@ from mlflow.tracking import MlflowClient
 class MlflowArtifactDataSet(AbstractVersionedDataSet):
     """This class is a wrapper for any kedro AbstractDataSet.
     It decorates their ``save`` method to log the dataset in mlflow when ``save`` is called.
-
     """
 
     def __new__(

--- a/kedro_mlflow/utils.py
+++ b/kedro_mlflow/utils.py
@@ -8,7 +8,3 @@ def _parse_requirements(path: Union[str, Path], encoding="utf-8") -> List:
             x.strip() for x in file_handler if x.strip() and not x.startswith("-r")
         ]
     return requirements
-
-
-class KedroContextError(Exception):
-    """Error occurred when loading project and running context pipeline."""

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "recommonmark==0.7.1",
             "sphinx_rtd_theme==0.5.2",
             "sphinx-markdown-tables==0.0.15",
+            "sphinx-click==3.0.1",
             "pandas>=1.0.0, <2.0.0",  # avoid to make readthedocs load rc version
             "numpy>=1.0.0, <2.0.0",  # bug on windows for numpy 1.19.0->1.19.4
         ],

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,12 @@ setup(
     install_requires=base_requirements,
     extras_require={
         "doc": [
-            "sphinx==4.1.1",
+            "sphinx==4.2.0",
             "recommonmark==0.7.1",
-            "sphinx_rtd_theme==0.5.2",
+            "sphinx_rtd_theme==1.0.0",
             "sphinx-markdown-tables==0.0.15",
             "sphinx-click==3.0.1",
+            "sphinx_copybutton==0.4.0",
             "pandas>=1.0.0, <2.0.0",  # avoid to make readthedocs load rc version
             "numpy>=1.0.0, <2.0.0",  # bug on windows for numpy 1.19.0->1.19.4
         ],
@@ -55,8 +56,8 @@ setup(
             "flake8==3.9.2",  # ensure consistency with pre-commit
         ],
         "dev": [
-            "black==21.7b0",  # pin black version because it is not compatible with a pip range (because of non semver version number)
-            "isort==5.9.2",  # ensure consistency with pre-commit
+            "black==21.9b0",  # pin black version because it is not compatible with a pip range (because of non semver version number)
+            "isort==5.9.3",  # ensure consistency with pre-commit
             "pre-commit>=2.0.0,<3.0.0",
             "jupyter>=1.0.0,<2.0.0",
         ],


### PR DESCRIPTION
## Description

Add support for #110

## Development notes

- Create an "API Documentation" folder in the docs, and use autodoc to document it.
- Note that many method are not properly documetned with docstrings yet, so I do not get rid of the 
07_Python_objects section yet.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
