### PR TITLE
:bug: Stop converting the reserved 'databricks' tracking uri keyword to a filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- :bug: The reserved keyword "databricks" is no longer converted to a local filepath before setting the ``MLFLOW_TRACKING_URI`` to enable integration with databricks managed platform. ([#248](https://github.com/Galileo-Galilei/kedro-mlflow/issues/124))
+
 ## [0.7.5] - 2021-09-21
 
 ### Added

--- a/kedro_mlflow/config/kedro_mlflow_config.py
+++ b/kedro_mlflow/config/kedro_mlflow_config.py
@@ -156,6 +156,11 @@ class KedroMlflowConfig(BaseModel):
             str -- A valid mlflow_tracking_uri
         """
 
+        # this is a special reserved keyword for mlflow which should not be converted to a path
+        # se: https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded
+        if uri == "databricks":
+            return uri
+
         # if no tracking uri is provided, we register the runs locally at the root of the project
         pathlib_uri = PurePath(uri)
 

--- a/tests/config/test_kedro_mlflow_config.py
+++ b/tests/config/test_kedro_mlflow_config.py
@@ -182,6 +182,15 @@ def test_kedro_mlflow_config_validate_uri_local(kedro_project_with_mlflow_conf, 
     )  # relative
 
 
+def test_kedro_mlflow_config_validate_uri_databricks(kedro_project_with_mlflow_conf):
+    # databricks is a reseved keyword which should not be modified
+    config_uri = KedroMlflowConfig._validate_uri(
+        uri="databricks", values={"project_path": kedro_project_with_mlflow_conf}
+    )
+
+    assert config_uri == "databricks"
+
+
 def test_from_dict_to_dict_idempotent(kedro_project_with_mlflow_conf):
     config = KedroMlflowConfig(project_path=kedro_project_with_mlflow_conf)
     original_config_dict = config.dict()


### PR DESCRIPTION
## Description

Close #248

## Development notes
Modify the KedroMlflowConfig._validate_uri() method to have a special treatment for the reserved keyword.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
