### PR TITLE
:recycle: Refactor mlflow configuration to match mlflow API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - :sparkles: :boom: The ``pipeline_ml_factory`` accepts 2 new arguments ``log_model_kwargs`` (which will be passed *as is* to ``mlflow.pyfunc.log_model``) and ``kpm_kwargs`` (which will be passed *as is* to ``KedroPipelineModel``). This ensures perfect consistency with mlflow API and offers new possibility like saving the project source code alongisde the model ([#67](https://github.com/Galileo-Galilei/kedro-mlflow/issues/67)). Note that ``model_signature``, ``conda_env`` and ``model_name`` arguments are removed, and replace respectively by ``log_model_kwargs["signature"]``, ``log_model_kwargs["conda_env"]`` and ``log_model_kwargs["artifact_path"]``.
 - :sparkles: :boom: The ``KedroPipelineModel`` custom mlflow model now accepts any kedro `Pipeline` as input (provided they have a single DataFrame input and a single output because this is an mlflow limitation) instead of only ``PipelineML`` objects. This simplifies the API for user who want to customise the model logging ([#171](https://github.com/Galileo-Galilei/kedro-mlflow/issues/171)). `KedroPipelineModel.__init__` argument `pipeline_ml` is renamed `pipeline` to reflect this change.
 - :wastebasket: `kedro_mlflow.io.metrics.MlflowMetricsDataSet` is no longer deprecated because there is no alternative for now to log many metrics at the same time.
+- :boom: Refactor ``mlflow.yml`` to match mlflow's API ([#77](https://github.com/Galileo-Galilei/kedro-mlflow/issues/77)). To migrate projects with ``kedro<0.8.0``, please update their ``mlflow.yml`` with `kedro mlflow init --force` command.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 [![SemVer](https://img.shields.io/badge/semver-2.0.0-green)](https://semver.org/)
 
 ----------------------------------------------------------
-| Software repository | Latest release | Total downloads |
-|---------------------|----------------|-----------------|
-| Pypi | [![PyPI version](https://badge.fury.io/py/kedro-mlflow.svg)](https://pypi.org/project/kedro-mlflow/) | [![Downloads](https://pepy.tech/badge/kedro-mlflow)](https://pepy.tech/project/kedro-mlflow) |
+| Software repository | Latest release                                                                                       | Total downloads                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Pypi                | [![PyPI version](https://badge.fury.io/py/kedro-mlflow.svg)](https://pypi.org/project/kedro-mlflow/) | [![Downloads](https://pepy.tech/badge/kedro-mlflow)](https://pepy.tech/project/kedro-mlflow) |
 
 **Code health**
 
 ----------------------------------------------------------
-| Branch | Tests | Coverage | Links | Documentation | Deployment | Activity |
-|--------|-------|----------|-------|---------------|------------|----------|
-| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master)|[![links](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/check-links/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Acheck-links+branch%3Amaster)|[![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/)|[![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish)|[![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.7.6)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.7.6...master)|
+| Branch   | Tests                                                                                                                                                                                            | Coverage                                                                                                                                                         | Links                                                                                                                                                                                                           | Documentation                                                                                                                           | Deployment                                                                                                                                                                                                | Activity                                                                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `master` | [![test](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/test/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Atest+branch%3Amaster) | [![codecov](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master/graph/badge.svg)](https://codecov.io/gh/Galileo-Galilei/kedro-mlflow/branch/master) | [![links](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/check-links/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=workflow%3Acheck-links+branch%3Amaster) | [![Documentation](https://readthedocs.org/projects/kedro-mlflow/badge/?version=stable)](https://kedro-mlflow.readthedocs.io/en/stable/) | [![publish](https://github.com/Galileo-Galilei/kedro-mlflow/workflows/publish/badge.svg?branch=master)](https://github.com/Galileo-Galilei/kedro-mlflow/actions?query=branch%3Amaster+workflow%3Apublish) | [![commit](https://img.shields.io/github/commits-since/Galileo-Galilei/kedro-mlflow/0.7.6)](https://github.com/Galileo-Galilei/kedro-mlflow/compare/0.7.6...master) |
 
 # What is kedro-mlflow?
 
@@ -63,9 +63,10 @@ The [release history](https://github.com/Galileo-Galilei/kedro-mlflow/blob/maste
 
 This package is still in active development. We use [SemVer](https://semver.org/) principles to version our releases. Until we reach `1.0.0` milestone, breaking changes will lead to `<minor>` version number increment, while releases which do not introduce breaking changes in the API will lead to `<patch>` version number increment.
 
-The user must be aware that we will not reach `1.0.0` milestone before Kedro does (mlflow has already reached `1.0.0`).
+The user must be aware that we will not reach `1.0.0` milestone before Kedro does (mlflow has already reached `1.0.0`). **That said, the API is considered as stable from 0.8.0 version and user can reliably consider that no consequent breaking change will happen unless absolutely necessary for Kedro compatibility.**
 
-If you want to see how to migrate from one version of `kedro-mlflow` to another, see the [migration guide](https://kedro-mlflow.readthedocs.io/en/stable/source/02_installation/03_migration_guide.html).
+If you want to migrate from an older version of `kedro-mlflow` to most recent ones, see the [migration guide](https://kedro-mlflow.readthedocs.io/en/stable/source/02_installation/03_migration_guide.html).
+
 
 # Can I contribute?
 

--- a/docs/source/02_installation/03_migration_guide.md
+++ b/docs/source/02_installation/03_migration_guide.md
@@ -2,11 +2,22 @@
 
 This page explains how to migrate an existing kedro project to a more up to date `kedro-mlflow` versions with breaking changes.
 
-## Migration from 0.5.0 to 0.6.0
+## Migration from 0.7.x to 0.8.x
+
+- Update the ``mlflow.yml`` configuration file with ``kedro mlflow init --force`` command
+- `pipeline_ml_factory(pipeline_ml=<your-pipeline-ml>,...)` (resp. `KedroPipelineModel(pipeline_ml=<your-pipeline-ml>, ...)`) first argument is renamed `pipeline`. Change the call to `pipeline_ml_factory(pipeline=<your-pipeline-ml>)` (resp. `KedroPipelineModel(pipeline=<your-pipeline-ml>, ...)`).
+- Change the call from `pipeline_ml_factory(..., model_signature=<model-signature>, conda_env=<conda-env>, model_name=<model_name>)` to `` pipeline_ml_factory(..., log_model_kwargs=dict(signature=<model-signature>, conda_env=<conda-env>, artifact_path=<model_name>})`. Notice that the arguments are renamed to match mlflow's and they are passed as a dict in `log_model_kwargs`.
+
+
+## Migration from 0.6.x to 0.7.x
+
+If you are working with ``kedro==0.17.0``, update your template to ``kedro>=0.17.1``.
+
+## Migration from 0.5.x to 0.6.x
 
 ``kedro==0.16.x`` is no longer supported. You need to update your project template to ``kedro==0.17.0`` template.
 
-## Migration from 0.4.1 to 0.5.0
+## Migration from 0.4.x to 0.5.x
 
 The only breaking change with the previous release is the format of ``KedroPipelineMLModel`` class. Hence, if you saved a pipeline as a Mlflow Model with `pipeline_ml_factory` in ``kedro-mlflow==0.4.x``, loading it (either with ``MlflowModelLoggerDataSet`` or ``mlflow.pyfunc.load_model``) with ``kedro-mlflow==0.5.0`` installed will raise an error. You will need either to retrain the model or to load it with ``kedro-mlflow==0.4.x``.
 
@@ -18,31 +29,28 @@ There are no breaking change in this patch release except if you retrieve the ml
 from kedro.framework.context import load_context
 from kedro_mlflow.config import get_mlflow_config
 
-context=load_context(".")
-mlflow_config=get_mlflow_config(context)
-mlflow_config.setup() # <-- add this line which did not exists in 0.4.0
+context = load_context(".")
+mlflow_config = get_mlflow_config(context)
+mlflow_config.setup()  # <-- add this line which did not exists in 0.4.0
 ```
 
-## Migration from 0.3.0 to 0.4.0
+## Migration from 0.3.x to 0.4.x
 
 ### Catalog entries
 
 Replace the following entries:
 
-|old                                    |new                                              |
-|:--------------------------------------|:------------------------------------------------|
-|`kedro_mlflow.io.MlflowArtifactDataSet`|`kedro_mlflow.io.artifacts.MlflowArtifactDataSet`|
-|`kedro_mlflow.io.MlflowMetricsDataSet` |`kedro_mlflow.io.metrics.MlflowMetricsDataSet`   |
+| old                                     | new                                               |
+| :-------------------------------------- | :------------------------------------------------ |
+| `kedro_mlflow.io.MlflowArtifactDataSet` | `kedro_mlflow.io.artifacts.MlflowArtifactDataSet` |
+| `kedro_mlflow.io.MlflowMetricsDataSet`  | `kedro_mlflow.io.metrics.MlflowMetricsDataSet`    |
 
 ### Hooks
 
 Hooks are now auto-registered if you use `kedro>=0.16.4`. You can remove the following entry from your `run.py`:
 
 ```python
-hooks = (
-    MlflowPipelineHook(),
-    MlflowNodeHook()
-)
+hooks = (MlflowPipelineHook(), MlflowNodeHook())
 ```
 
 ### KedroPipelineModel

--- a/kedro_mlflow/extras/extensions/ipython.py
+++ b/kedro_mlflow/extras/extensions/ipython.py
@@ -13,7 +13,7 @@ def reload_kedro_mlflow(line=None, local_ns=None):
     )  # project_path is a global variable defined by init_kedro
     mlflow_config = get_mlflow_config()  # can only be called if a session exist
 
-    mlflow_client = MlflowClient(tracking_uri=mlflow_config.mlflow_tracking_uri)
+    mlflow_client = MlflowClient(tracking_uri=mlflow_config.server.mlflow_tracking_uri)
     global_variables = {"mlflow_client": mlflow_client}
     get_ipython().push(variables=global_variables)
     get_ipython().run_cell("import mlflow", "", "")

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -159,7 +159,7 @@ def ui(env, port, host):
                 "mlflow",
                 "ui",
                 "--backend-store-uri",
-                mlflow_conf.mlflow_tracking_uri,
+                mlflow_conf.server.mlflow_tracking_uri,
                 "--host",
                 host,
                 "--port",

--- a/kedro_mlflow/framework/hooks/node_hook.py
+++ b/kedro_mlflow/framework/hooks/node_hook.py
@@ -55,11 +55,11 @@ class MlflowNodeHook:
         if self._is_mlflow_enabled:
             mlflow_config = get_mlflow_config()
 
-            self.flatten = mlflow_config.hooks.node.flatten_dict_params
-            self.recursive = mlflow_config.hooks.node.recursive
-            self.sep = mlflow_config.hooks.node.sep
-            self.long_parameters_strategy = (
-                mlflow_config.hooks.node.long_parameters_strategy
+            self.flatten = mlflow_config.tracking.params.dict_params.flatten
+            self.recursive = mlflow_config.tracking.params.dict_params.recursive
+            self.sep = mlflow_config.tracking.params.dict_params.sep
+            self.long_params_strategy = (
+                mlflow_config.tracking.params.long_params_strategy
             )
 
     @hook_impl
@@ -107,19 +107,19 @@ class MlflowNodeHook:
         if str_value_length <= MAX_PARAM_VAL_LENGTH:
             return mlflow.log_param(name, value)
         else:
-            if self.long_parameters_strategy == "fail":
+            if self.long_params_strategy == "fail":
                 raise ValueError(
                     f"Parameter '{name}' length is {str_value_length}, "
                     f"while mlflow forces it to be lower than '{MAX_PARAM_VAL_LENGTH}'. "
-                    "If you want to bypass it, try to change 'long_parameters_strategy' to"
+                    "If you want to bypass it, try to change 'long_params_strategy' to"
                     " 'tag' or 'truncate' in the 'mlflow.yml'configuration file."
                 )
-            elif self.long_parameters_strategy == "tag":
+            elif self.long_params_strategy == "tag":
                 self._logger.warning(
                     f"Parameter '{name}' (value length {str_value_length}) is set as a tag."
                 )
                 mlflow.set_tag(name, value)
-            elif self.long_parameters_strategy == "truncate":
+            elif self.long_params_strategy == "truncate":
                 self._logger.warning(
                     f"Parameter '{name}' (value length {str_value_length}) is truncated to its {MAX_PARAM_VAL_LENGTH} first characters."
                 )

--- a/kedro_mlflow/framework/hooks/pipeline_hook.py
+++ b/kedro_mlflow/framework/hooks/pipeline_hook.py
@@ -111,13 +111,13 @@ class MlflowPipelineHook:
             mlflow_config = get_mlflow_config()
             mlflow_config.setup()
 
-            run_name = mlflow_config.run.name or run_params["pipeline_name"]
+            run_name = mlflow_config.tracking.run.name or run_params["pipeline_name"]
 
             mlflow.start_run(
-                run_id=mlflow_config.run.id,
-                experiment_id=mlflow_config._experiment.experiment_id,
+                run_id=mlflow_config.tracking.run.id,
+                experiment_id=mlflow_config.tracking.experiment._experiment.experiment_id,
                 run_name=run_name,
-                nested=mlflow_config.run.nested,
+                nested=mlflow_config.tracking.run.nested,
             )
             # Set tags only for run parameters that have values.
             mlflow.set_tags({k: v for k, v in run_params.items() if v})

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -9,7 +9,7 @@ def _assert_mlflow_enabled(pipeline_name: str) -> bool:
     # TODO: we may want to enable to filter on tags
     # but we need to deal with the case when several tags are passed
     # what to do if 1 out of 2 is in the list?
-    disabled_pipelines = mlflow_config.disable_tracking.pipelines
+    disabled_pipelines = mlflow_config.tracking.disable_tracking.pipelines
     if pipeline_name in disabled_pipelines:
         return False
 

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -1,11 +1,10 @@
-# GLOBAL CONFIGURATION -------------------
+# SERVER CONFIGURATION -------------------
 
 # `mlflow_tracking_uri` is the path where the runs will be recorded.
 # For more informations, see https://www.mlflow.org/docs/latest/tracking.html#where-runs-are-recorded
 # kedro-mlflow accepts relative path from the project root.
 # For instance, default `mlruns` will create a mlruns folder
 # at the root of the project
-mlflow_tracking_uri: mlruns
 
 # All credentials needed for mlflow must be stored in credentials .yml as a dict
 # they will be exported as environment variable
@@ -17,37 +16,35 @@ mlflow_tracking_uri: mlruns
 # > in this file `mlflow.yml`:
 # credentials: mlflow_credentials
 
-credentials: null  # must be a valid key in credentials.yml
-
-# You can specify a list of pipeline names for which tracing will be disabled
-# Running "kedro run --pipeline=<pipeline_name>" will not log parameters
-# in a new mlflow run
-disable_tracking:
-  pipelines: []
-
-# EXPERIMENT-RELATED PARAMETERS ----------
-
-# `name` is the name of the experiment (~subfolder
-# where the runs are recorded). Change the name to
-# switch between different experiments
-experiment:
-  name: {{ python_package }}
-  restore_if_deleted: True  # if the specified `name` belongs to a previously deleted experiment, should we restore it?
+server:
+  mlflow_tracking_uri: mlruns
+  stores_environment_variables: {} # any valid mlflow variables either for backend store or artifact store (e.g. MLFLOW_S3_ENDPOINT_URL), see: https://www.mlflow.org/docs/latest/tracking.html#amazon-s3-and-s3-compatible-storage
+  credentials: null  # must be a valid key in credentials.yml which refers to a dict of sensituve mlflow environment variables (password, tokens...)
 
 
-# RUN-RELATED PARAMETERS -----------------
+tracking:
+  # You can specify a list of pipeline names for which tracking will be disabled
+  # Running "kedro run --pipeline=<pipeline_name>" will not log parameters
+  # in a new mlflow run
 
-run:
-  id: null # if `id` is None, a new run will be created
-  name: null # if `name` is None, pipeline name will be used for the run name
-  nested: True  # # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+  disable_tracking:
+    pipelines: []
 
-hooks:
-  node:
-    flatten_dict_params: False  # if True, parameter which are dictionary will be splitted in multiple parameters when logged in mlflow, one for each key.
-    recursive: True  # Should the dictionary flattening be applied recursively (i.e for nested dictionaries)? Not use if `flatten_dict_params` is False.
-    sep: "." # In case of recursive flattening, what separator should be used between the keys? E.g. {hyperaparam1: {p1:1, p2:2}}will be logged as hyperaparam1.p1 and hyperaparam1.p2 oin mlflow.
-    long_parameters_strategy: fail # One of ["fail", "tag", "truncate" ] If a parameter is above mlflow limit (currently 250), what should kedro-mlflow do? -> fail, set as a tag instead of a parameter, or truncate it to its 250 first letters?
+  experiment:
+    name: {{ python_package }}
+    restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
+
+  run:
+    id: null # if `id` is None, a new run will be created
+    name: null # if `name` is None, pipeline name will be used for the run name
+    nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+
+  params:
+    dict_params:
+      flatten: False  # if True, parameter which are dictionary will be splitted in multiple parameters when logged in mlflow, one for each key.
+      recursive: True  # Should the dictionary flattening be applied recursively (i.e for nested dictionaries)? Not use if `flatten_dict_params` is False.
+      sep: "." # In case of recursive flattening, what separator should be used between the keys? E.g. {hyperaparam1: {p1:1, p2:2}} will be logged as hyperaparam1.p1 and hyperaparam1.p2 in mlflow.
+    long_params_strategy: fail # One of ["fail", "tag", "truncate" ] If a parameter is above mlflow limit (currently 250), what should kedro-mlflow do? -> fail, set as a tag instead of a parameter, or truncate it to its 250 first letters?
 
 
 # UI-RELATED PARAMETERS -----------------

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -81,7 +81,7 @@ def test_cli_init_existing_config(monkeypatch, kedro_project_with_mlflow_conf):
     ) as session:
         context = session.load_context()
         # emulate first call by writing a mlflow.yml file
-        yaml_str = yaml.dump(dict(mlflow_tracking_uri="toto"))
+        yaml_str = yaml.dump(dict(server=dict(mlflow_tracking_uri="toto")))
         (
             kedro_project_with_mlflow_conf / context.CONF_ROOT / "local" / "mlflow.yml"
         ).write_text(yaml_str)
@@ -92,7 +92,7 @@ def test_cli_init_existing_config(monkeypatch, kedro_project_with_mlflow_conf):
         assert "A 'mlflow.yml' already exists" in result.output
 
         # check the file remains unmodified
-        assert get_mlflow_config().mlflow_tracking_uri.endswith("toto")
+        assert get_mlflow_config().server.mlflow_tracking_uri.endswith("toto")
 
 
 def test_cli_init_existing_config_force_option(monkeypatch, kedro_project):
@@ -116,7 +116,7 @@ def test_cli_init_existing_config_force_option(monkeypatch, kedro_project):
         assert "successfully updated" in result.output
 
         # check the file remains unmodified
-        assert get_mlflow_config().mlflow_tracking_uri.endswith("mlruns")
+        assert get_mlflow_config().server.mlflow_tracking_uri.endswith("mlruns")
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/hooks/test_all_hooks.py
+++ b/tests/framework/hooks/test_all_hooks.py
@@ -105,10 +105,10 @@ def catalog_config(kedro_project_path):
 @pytest.fixture
 def mlflow_config_wo_tracking():
     # this is the default configuration except that oine pipeline is deactivated
-    return {
+    return dict(
         # "mlflow_tracking_uri": "mlruns",
         # "credentials": None,
-        "disable_tracking": {"pipelines": ["pipeline_off"]},
+        tracking=dict(disable_tracking=dict(pipelines=["pipeline_off"]))
         # "experiments": MOCK_PACKAGE_NAME,
         # "run": {"id": None, "name": None, "nested": True},
         # "ui": {"port": None, "host": None},
@@ -118,7 +118,7 @@ def mlflow_config_wo_tracking():
         #     "sep": ".",
         #     "long_parameters_strategy": "fail",
         # },
-    }
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/framework/hooks/test_node_hook.py
+++ b/tests/framework/hooks/test_node_hook.py
@@ -86,9 +86,11 @@ def test_pipeline_run_hook_getting_configs(
     _write_yaml(
         kedro_project / "conf" / "local" / "mlflow.yml",
         dict(
-            hooks=dict(node=dict(flatten_dict_params=True, recursive=False, sep="-")),
+            tracking=dict(
+                params=dict(dict_params=dict(flatten=True, recursive=False, sep="-")),
+            ),
         ),
-    ),
+    )
 
     bootstrap_project(kedro_project)
     with KedroSession.create(
@@ -107,7 +109,7 @@ def test_pipeline_run_hook_getting_configs(
 
 
 @pytest.mark.parametrize(
-    "flatten_dict_params,expected",
+    "flatten,expected",
     [
         (True, {"param1": "1", "parameters-param1": "1", "parameters-param2": "2"}),
         (False, {"param1": "1", "parameters": "{'param1': 1, 'param2': 2}"}),
@@ -119,7 +121,7 @@ def test_node_hook_logging(
     dummy_catalog,
     dummy_pipeline,
     dummy_node,
-    flatten_dict_params,
+    flatten,
     expected,
 ):
 
@@ -136,13 +138,11 @@ def test_node_hook_logging(
     _write_yaml(
         kedro_project / "conf" / "base" / "mlflow.yml",
         dict(
-            hooks=dict(
-                node=dict(
-                    flatten_dict_params=flatten_dict_params, recursive=False, sep="-"
-                )
-            ),
+            tracking=dict(
+                params=dict(dict_params=dict(flatten=flatten, recursive=False, sep="-"))
+            )
         ),
-    ),
+    )
 
     mlflow_node_hook = MlflowNodeHook()
 
@@ -188,7 +188,7 @@ def test_node_hook_logging_below_limit_all_strategy(
     _write_yaml(
         kedro_project / "conf" / "local" / "mlflow.yml",
         dict(
-            hooks=dict(node=dict(long_parameters_strategy=strategy)),
+            tracking=dict(params=dict(long_params_strategy=strategy)),
         ),
     )
 
@@ -235,7 +235,7 @@ def test_node_hook_logging_above_limit_truncate_strategy(
     _write_yaml(
         kedro_project / "conf" / "local" / "mlflow.yml",
         dict(
-            hooks=dict(node=dict(long_parameters_strategy="truncate")),
+            tracking=dict(params=dict(long_params_strategy="truncate")),
         ),
     )
 
@@ -284,7 +284,9 @@ def test_node_hook_logging_above_limit_fail_strategy(
     _write_yaml(
         kedro_project / "conf" / "local" / "mlflow.yml",
         dict(
-            hooks=dict(node=dict(long_parameters_strategy="fail")),
+            tracking=dict(
+                params=dict(long_params_strategy="fail"),
+            ),
         ),
     )
 
@@ -337,7 +339,7 @@ def test_node_hook_logging_above_limit_tag_strategy(
     _write_yaml(
         kedro_project / "conf" / "local" / "mlflow.yml",
         dict(
-            hooks=dict(node=dict(long_parameters_strategy="tag")),
+            tracking=dict(params=dict(long_params_strategy="tag")),
         ),
     )
 

--- a/tests/framework/hooks/test_pipeline_hook.py
+++ b/tests/framework/hooks/test_pipeline_hook.py
@@ -413,7 +413,7 @@ def test_mlflow_pipeline_hook_with_different_pipeline_types(
         )
         # test : parameters should have been logged
         mlflow_conf = get_mlflow_config()
-        mlflow_client = MlflowClient(mlflow_conf.mlflow_tracking_uri)
+        mlflow_client = MlflowClient(mlflow_conf.server.mlflow_tracking_uri)
         run_data = mlflow_client.get_run(run_id).data
 
         # all run_params are recorded as tags
@@ -522,7 +522,7 @@ def test_mlflow_pipeline_hook_metric_metrics_with_run_id(
     with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
 
         mlflow_conf = get_mlflow_config()
-        mlflow.set_tracking_uri(mlflow_conf.mlflow_tracking_uri)
+        mlflow.set_tracking_uri(mlflow_conf.server.mlflow_tracking_uri)
 
         with mlflow.start_run():
             existing_run_id = mlflow.active_run().info.run_id
@@ -579,7 +579,7 @@ def test_mlflow_pipeline_hook_metric_metrics_with_run_id(
             catalog=dummy_catalog_with_run_id,
         )
 
-        mlflow_client = MlflowClient(mlflow_conf.mlflow_tracking_uri)
+        mlflow_client = MlflowClient(mlflow_conf.server.mlflow_tracking_uri)
         # the first run is created in Default (id 0),
         # but the one initialised in before_pipeline_run
         # is create  in kedro_project experiment (id 1)
@@ -621,7 +621,7 @@ def test_mlflow_pipeline_hook_save_pipeline_ml_with_parameters(
     with KedroSession.create(project_path=kedro_project_with_mlflow_conf):
 
         mlflow_conf = get_mlflow_config()
-        mlflow.set_tracking_uri(mlflow_conf.mlflow_tracking_uri)
+        mlflow.set_tracking_uri(mlflow_conf.server.mlflow_tracking_uri)
 
         catalog_with_parameters = DataCatalog(
             {
@@ -795,7 +795,7 @@ def test_on_pipeline_error(
 
         # the run we want is the last one in the configuration experiment
         mlflow_client = MlflowClient(tracking_uri)
-        experiment = mlflow_client.get_experiment_by_name(kmc.experiment.name)
+        experiment = mlflow_client.get_experiment_by_name(kmc.tracking.experiment.name)
         failing_run_info = MlflowClient(tracking_uri).list_run_infos(
             experiment.experiment_id
         )[0]

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 
-from kedro_mlflow.config.kedro_mlflow_config import ExperimentOptions, KedroMlflowConfig
+from kedro_mlflow.config.kedro_mlflow_config import KedroMlflowConfig
 from kedro_mlflow.framework.cli.cli import TEMPLATE_FOLDER_PATH
 from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
 
@@ -10,7 +10,7 @@ from kedro_mlflow.framework.cli.cli_utils import write_jinja_template
 def template_mlflowyml(tmp_path):
     # the goal is to discover all potential ".py" files
     # but for now there is only "run.py"
-    # # this is rather a safeguard for further add
+    # this is rather a safeguard for further add
     raw_template_path = TEMPLATE_FOLDER_PATH / "mlflow.yml"
     rendered_template_path = tmp_path / raw_template_path.name
     tags = {
@@ -33,7 +33,15 @@ def test_mlflow_yml_rendering(template_mlflowyml):
     # and here we do not want to check the path
     expected_config = KedroMlflowConfig.construct(
         project_path="fake/path",
-        experiment=ExperimentOptions(name="fake_project"),  # check for proper rendering
+        tracking=dict(
+            disable_tracking=dict(pipelines=[]),
+            experiment=dict(name="fake_project", restore_if_deleted=True),
+            params=dict(
+                dict_params=dict(flatten=False, recursive=True, sep="."),
+                long_params_strategy="fail",
+            ),
+            run=dict(id=None, name=None, nested=True),
+        ),  # check for proper rendering
     )
 
     assert mlflow_config == expected_config.dict(exclude={"project_path"})


### PR DESCRIPTION
## Description
Close #77

## Development notes

The config entries are renamed for readibility and consistency with the mlflow API. 

The mlflow.yml now looks like this: 

```yaml
server:
  mlflow_tracking_uri: mlruns
  stores_environment_variables: {}
  credentials: null

tracking:
  disable_tracking:
    pipelines: []
  experiment:
    name: {{ python_package }}
    restore_if_deleted: True
  run:
    id: null 
    name: null 
    nested: True 
  params:
    dict_params:
      flatten: False
      recursive: True
      sep: "." 
    long_params_strategy: fail 

ui:
  port: "5000" # the port to use for the ui. Use mlflow default with 5000.
  host: "127.0.0.1"  # the host to use for the ui. Use mlflow efault of "127.0.0.1".

```

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
