### PR TITLE
Automatically persist parameters in modelify command (#282)

### DIFF
--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -27,7 +27,7 @@ def test_mlflow_yml_rendering(template_mlflowyml):
 
     # the mlflow yml file must be consistent with the default in KedroMlflowConfig for readibility
     with open(template_mlflowyml, "r") as file_handler:
-        mlflow_config = yaml.load(file_handler)
+        mlflow_config = yaml.safe_load(file_handler)
 
     # note: Using Pydantic model Construct method skip all validations
     # and here we do not want to check the path


### PR DESCRIPTION
## Description

Close #282. Persisting paramters in the ``modelify`` command is consistent with ``pipeline_ml_factory`` and ``after_pipeline_run`` hook

## Development notes

- persists parameters in modelify command in the same way we do for ``after_pipeline_run`` hook.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
