### PR TITLE
:construction_worker: Make user choose the part of the version to update in a dropdown list during release (#57)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,8 +5,13 @@ on:
     inputs:
       version_part:
         description: The part of the version to update (patch, minor or major)
-        required: true
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
         default: 'minor'
+        required: true
 
 jobs:
   prepare-release:
@@ -25,7 +30,6 @@ jobs:
     - name: Validate inputs
       run: |
         echo "INPUT_VERSION_PART: ${{ github.event.inputs.version_part }}"
-        python -c "if '${{ github.event.inputs.version_part }}' not in ['patch', 'minor', 'major']:   raise ValueError(\"'${{ github.event.inputs.version_part }}' must be one of ['patch', 'minor', 'major'])\")"
     - name: Bump the version number  # bump2version is a maintained fork of original bumpversion
       id: bump_version
       run: |


### PR DESCRIPTION
## Description

Avoid operational errors when typing the part of the version to update when releasing the package

## Development notes

Use the new feature in github action which enable specifying the list of choices in a workflow_dispatch](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/) to define the part of the version to bump

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- N/A Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- N/A Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- N/A Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
