### PR TITLE
Pass extra arg log_model_kwargs

### DIFF
--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -167,7 +167,7 @@ class PipelineML(Pipeline):
 
     def _turn_pipeline_to_ml(self, pipeline: Pipeline):
         return PipelineML(
-            nodes=pipeline.nodes, inference=self.inference, input_name=self.input_name
+            nodes=pipeline.nodes, inference=self.inference, input_name=self.input_name, log_model_kwargs=self.log_model_kwargs
         )
 
     def only_nodes(self, *node_names: str) -> "Pipeline":  # pragma: no cover


### PR DESCRIPTION
## Description
Function `_turn_pipeline_to_ml`, return `PipelineML` without passing extra argument `log_model_kwargs`

## Development notes
What have you changed, and how has this been tested?

## Checklist

- [ ] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
