### PR TITLE
:bug: Correctly pass kpm_kwargs and log_model_kwargs to pipeline_ml_factory instead of always using default values (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   :bug: Make ``pipeline_ml_factory`` correctly pass ``kpm_kwargs`` and ``log_model_kwargs`` instead of always using the default values. ([#329](https://github.com/Galileo-Galilei/kedro-mlflow/issues/329))
+
 ## [0.11.0] - 2022-06-18
 
 ### Added

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -68,9 +68,9 @@ class PipelineML(Pipeline):
                     when loaded in memory
                     - `runner`: the kedro runner to run the model with
             log_model_kwargs:
-                extra arguments to be passed to `mlflow.pyfunc.log_model`
-                - "signature" accepts an extra "auto" which automatically infer the signature
-                based on "input_name" dataset
+                extra arguments to be passed to `mlflow.pyfunc.log_model`, e.g.:
+                    - "signature" accepts an extra "auto" which automatically infer the signature
+                    based on "input_name" dataset
 
         """
 
@@ -80,16 +80,11 @@ class PipelineML(Pipeline):
         self.input_name = input_name
         # they will be passed to KedroPipelineModel to enable flexibility
 
-        kpm_kwargs_with_default = self.KPM_KWARGS_DEFAULT.copy()
         kpm_kwargs = kpm_kwargs or {}
-        kpm_kwargs_with_default.update(kpm_kwargs)
-        self.kpm_kwargs = kpm_kwargs_with_default
+        self.kpm_kwargs = {**self.KPM_KWARGS_DEFAULT, **kpm_kwargs}
 
-        log_model_kwargs_with_default = self.LOG_MODEL_KWARGS_DEFAULT.copy()
         log_model_kwargs = log_model_kwargs or {}
-        log_model_kwargs_with_default.update(log_model_kwargs)
-        self.log_model_kwargs = log_model_kwargs_with_default
-
+        self.log_model_kwargs = {**self.LOG_MODEL_KWARGS_DEFAULT, **log_model_kwargs}
         self._check_consistency()
 
     @property
@@ -167,7 +162,11 @@ class PipelineML(Pipeline):
 
     def _turn_pipeline_to_ml(self, pipeline: Pipeline):
         return PipelineML(
-            nodes=pipeline.nodes, inference=self.inference, input_name=self.input_name
+            nodes=pipeline.nodes,
+            inference=self.inference,
+            input_name=self.input_name,
+            kpm_kwargs=self.kpm_kwargs,
+            log_model_kwargs=self.log_model_kwargs,
         )
 
     def only_nodes(self, *node_names: str) -> "Pipeline":  # pragma: no cover

--- a/tests/io/models/test_mlflow_model_logger_dataset.py
+++ b/tests/io/models/test_mlflow_model_logger_dataset.py
@@ -336,7 +336,6 @@ def test_pyfunc_flavor_python_model_save_and_load(
     model_config2 = model_config.copy()
     model_config2["config"]["run_id"] = current_run_id
     mlflow_model_ds2 = MlflowModelLoggerDataSet.from_config(**model_config2)
-    print(model_config)
 
     loaded_model = mlflow_model_ds2.load()
 


### PR DESCRIPTION
## Description
Close #329

## Development notes

- pass ``kpm_kwargs`` and ``log_model_kwargs`` to ``_turn_pipeline_to_ml`` method of ``PipelineML``
- refactor merge with default for readibility

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
