### PR TITLE
Refactor KedroMlflowConfig to avoid dependency on project_path at instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Fixed
 
--   :bug: Make ``pipeline_ml_factory`` correctly pass ``kpm_kwargs`` and ``log_model_kwargs`` instead of always using the default values. ([#329](https://github.com/Galileo-Galilei/kedro-mlflow/issues/329))
+-   :bug: Make ``pipeline_ml_factory`` now correctly uses ``kpm_kwargs`` and ``log_model_kwargs`` instead of always using the default values. ([#329](https://github.com/Galileo-Galilei/kedro-mlflow/issues/329))
+
+### Changed
+
+-   :recycle: Refactor `KedroMlflowConfig` which no longer needs the ``project_path`` at instantiation. The uri validaiton is done at ``setup()`` time to be able to use the configuration not at a root of a kedro project. This is *not* considered as a breaking change, because the recommended way to retrieve the config is to use ``session.load_context().mlflow`` which automatically calls ``setup()`` and hence behaviour inside a kedro project is unmodified. ([#314](https://github.com/Galileo-Galilei/kedro-mlflow/issues/314))
 
 ## [0.11.0] - 2022-06-18
 

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -63,7 +63,6 @@ class MlflowHook:
             raise KedroMlflowConfigError(
                 "No 'mlflow.yml' config file found in environment. Use ``kedro mlflow init`` command in CLI to create a default config file."
             )
-        conf_mlflow_yml["project_path"] = context.project_path
         mlflow_config = KedroMlflowConfig.parse_obj(conf_mlflow_yml)
         mlflow_config.setup(context)  # setup global mlflow configuration
 

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -277,14 +277,15 @@ def test_ui_open_http_uri(monkeypatch, mocker, tmp_path):
     project_path = tmp_path / config["repo_name"]
     shutil.rmtree(project_path / "src" / "tests")  # avoid conflicts with pytest
 
-    mlflow_config = KedroMlflowConfig(project_path=project_path.as_posix())
-    mlflow_config.server.mlflow_tracking_uri = "http://google.com"
+    mlflow_config = KedroMlflowConfig(
+        server=dict(mlflow_tracking_uri="http://google.com")
+    )
 
     with open(
-        (mlflow_config.project_path / "conf" / "local" / "mlflow.yml").as_posix(), "w"
+        (project_path / "conf" / "local" / "mlflow.yml").as_posix(), "w"
     ) as fhandler:
         yaml.dump(
-            mlflow_config.dict(exclude={"project_path"}),
+            mlflow_config.dict(),
             fhandler,
             default_flow_style=False,
         )


### PR DESCRIPTION
## Description
 
Close #314

## Development notes

- KedroMlflowConfig no longer takes ``project path`` at instantiation, instead it is retrieved from context in ``KedroMlflowConfig.setup()``
- no error is raised if the config is instantiated outisde of a kedro project

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
