### PR TITLE
:sparkles: Enable running pipeline without mlflow.yml file (#328)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       rev: 22.3.0
       hooks:
           - id: black
-            language_version: python3.7
+            language_version: python3.9
     - repo: https://github.com/timothycrosley/isort
       rev: 5.10.1
       hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+-   :sparkles: ``kedro-mlflow`` now runs even without a ``mlflow.yml`` file in your ``conf/<env>`` folder. As a consequence, running ``kedro mlflow init`` is now optional and should be only used for advanced configuration. ([#328](https://github.com/Galileo-Galilei/kedro-mlflow/issues/328))
+
+
 ## [0.11.1] - 2022-07-06
 
 ### Fixed

--- a/docs/source/02_installation/02_setup.md
+++ b/docs/source/02_installation/02_setup.md
@@ -14,9 +14,14 @@ In order to use the ``kedro-mlflow`` plugin, you need to setup its configuration
 
 ### Setting up the ``kedro-mlflow`` configuration file
 
-``kedro-mlflow`` is [configured](../07_python_objects/05_Configuration.md) through an ``mlflow.yml`` file. The recommended way to initialize the `mlflow.yml` is by using [the ``kedro-mlflow`` CLI](../07_python_objects/04_CLI.md). **It is mandatory for the plugin to work.**
 
-Set the working directory at the root of your kedro project (i.e. the folder with the ``.kedro.yml`` file)
+``kedro-mlflow`` is [configured](../07_python_objects/05_Configuration.md) through an ``mlflow.yml`` file. The recommended way to initialize the `mlflow.yml` is by using [the ``kedro-mlflow`` CLI](../07_python_objects/04_CLI.md), but you can create it manually.
+
+```{note}
+Since ``kedro-mlflow>=0.11.2``, the configuration file is optional. However, the plugin will use default ``mlflow`` configuration. Specifically, the runs will be stored in a ``mlruns`` folder at the root fo the kedro project since no ``mlflow_tracking_uri`` is configured.
+```
+
+Set the working directory at the root of your kedro project:
 
 ```console
 cd path/to/your/project
@@ -58,5 +63,5 @@ If you have turned off plugin automatic registration, you can register its hooks
 # <your_project>/src/<your_project>/settings.py
 from kedro_mlflow.framework.hooks import MlflowHook
 
-HOOKS = (MlflowHook,)
+HOOKS = (MlflowHook(),)
 ```

--- a/docs/source/02_installation/03_migration_guide.md
+++ b/docs/source/02_installation/03_migration_guide.md
@@ -34,7 +34,7 @@ with KedroSession.create(
     project_path=project_path,
 ) as session:
     context = session.load_context()
-    print(context.mlflow)  # this is were mlflow configuraiton is sotred
+    print(context.mlflow)  # this is where mlflow configuration is stored
 ```
 
 3. Remove the ``server.stores_environment_variables`` key from ``mlflow.yml``. This is a dead key which was unused. It will now throw an error if it is still written in ``mlflow.yml``.  

--- a/kedro_mlflow/config/kedro_mlflow_config.py
+++ b/kedro_mlflow/config/kedro_mlflow_config.py
@@ -207,7 +207,3 @@ def _validate_mlflow_tracking_uri(project_path: str, uri: Optional[str]) -> str:
             valid_uri = uri
 
     return valid_uri
-
-
-class KedroMlflowConfigError(Exception):
-    """Error occurred when loading the configuration"""


### PR DESCRIPTION
## Description
Close #328

## Development notes
Change after_context_created hook to use default configuration instead of raising an error when no mlflow.yml file exists.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
