### PR TITLE
Set logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+-   :loud_sound: `kedro-mlflow` has its default logging level set to ``INFO``. This was the default for ``kedro<=0.18.1``. For ``kedro>=0.18.2``, you can change the level in ``logging.yml`` ([#348](https://github.com/Galileo-Galilei/kedro-mlflow/issues/348))
+
 ## [0.11.2] - 2022-08-28
 
 ### Changed

--- a/kedro_mlflow/__init__.py
+++ b/kedro_mlflow/__init__.py
@@ -1,3 +1,7 @@
 """kedro-mlflow plugin constants
 """
 __version__ = "0.11.2"
+
+import logging
+
+logging.getLogger("kedro-mlflow").setLevel(logging.INFO)

--- a/kedro_mlflow/__init__.py
+++ b/kedro_mlflow/__init__.py
@@ -4,4 +4,5 @@ __version__ = "0.11.2"
 
 import logging
 
-logging.getLogger("kedro-mlflow").setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)

--- a/kedro_mlflow/__init__.py
+++ b/kedro_mlflow/__init__.py
@@ -4,5 +4,4 @@ __version__ = "0.11.2"
 
 import logging
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logging.getLogger(__name__).setLevel(logging.INFO)

--- a/kedro_mlflow/mlflow/kedro_pipeline_model.py
+++ b/kedro_mlflow/mlflow/kedro_pipeline_model.py
@@ -165,7 +165,7 @@ class KedroPipelineModel(PythonModel):
                     self._logger.info(
                         (
                             f"The parameter '{name[7:]}' is persisted (as pickle) "
-                            "at the following location: '{artifact_path}'"
+                            "at the following location: f'{artifact_path}'"
                         )
                     )
                 else:

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -259,12 +259,6 @@ def test_modelify_logs_in_mlflow(monkeypatch, example_repo, artifacts_list):
     stripped_output = re.sub(r"\w+\.py:\d+", "", stripped_output)
     stripped_output = re.sub(r"[ \n]+", " ", stripped_output)
 
-    with open(
-        r"C:\Users\Yolan\Documents\DEVELOPPEMENT\kedro-mlflow\bidouille.txt",
-        mode="w",
-        encoding="utf-8",
-    ) as fh:
-        fh.write(stripped_output)
     for artifact in artifacts_list:
         assert (
             f"The data_set '{artifact}' is added to the Pipeline catalog"

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -252,7 +252,7 @@ def test_modelify_logs_in_mlflow(monkeypatch, example_repo, artifacts_list):
     assert result.exit_code == 0
     for artifact in artifacts_list:
         assert (
-            f"The data_set '{artifact}' is added to the Pipeline catalog"
+            f"The data_set \x1b[32m'{artifact}'\x1b[0m is added to the Pipeline catalog"
             in result.output
         )
     assert "Model successfully logged" in result.output

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from pathlib import Path
 
@@ -250,12 +251,26 @@ def test_modelify_logs_in_mlflow(monkeypatch, example_repo, artifacts_list):
     )
 
     assert result.exit_code == 0
+    # parse the log
+    stripped_output = re.sub(r"\[.+\]", "", result.output)
+    stripped_output = re.sub(
+        "(TRACE|DEBUG|INFO|WARNING|ERROR|CRITICAL)", "", stripped_output
+    )
+    stripped_output = re.sub(r"\w+\.py:\d+", "", stripped_output)
+    stripped_output = re.sub(r"[ \n]+", " ", stripped_output)
+
+    with open(
+        r"C:\Users\Yolan\Documents\DEVELOPPEMENT\kedro-mlflow\bidouille.txt",
+        mode="w",
+        encoding="utf-8",
+    ) as fh:
+        fh.write(stripped_output)
     for artifact in artifacts_list:
         assert (
-            f"The data_set \x1b[32m'{artifact}'\x1b[0m is added to the Pipeline catalog"
-            in result.output
+            f"The data_set '{artifact}' is added to the Pipeline catalog"
+            in stripped_output
         )
-    assert "Model successfully logged" in result.output
+    assert "Model successfully logged" in stripped_output
     assert len(runs_list_after_cmd) - len(runs_list_before_cmd) == 1
 
 


### PR DESCRIPTION
## Description

Close #348 

## Development notes

Set the logging level in the root ``__init__.py`` so it is set globally. 

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
