### PR TITLE
:bug: Use project_name as default experiment_name even if it is not specified in mlflow.yml (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 -   :bug: ``kedro-mlflow`` now use the ``package_name`` as experiment name by default if it is not specified. This is done to ensure consistency with the behaviour with no ``mlflow.yml`` file ([#328](https://github.com/Galileo-Galilei/kedro-mlflow/issues/328))
+-   :memo: Update broken links to the most recent kedro and mlflow documentation
 
 ## [0.11.2] - 2022-08-28
 
@@ -238,7 +239,7 @@
 -   :sparkles: `pipeline_ml_factory` now accepts that `inference` pipeline `inputs` may be in `training` pipeline `inputs` ([#71](https://github.com/Galileo-Galilei/kedro-mlflow/issues/71))
 -   :sparkles: `pipeline_ml_factory` now infer automatically the schema of the input dataset to validate data automatically at inference time. The output schema can be declared manually in `model_signature` argument ([#70](https://github.com/Galileo-Galilei/kedro-mlflow/issues/70))
 -   :sparkles: Add two DataSets for model logging and saving: `MlflowModelLoggerDataSet` and `MlflowModelSaverDataSet` ([#12](https://github.com/Galileo-Galilei/kedro-mlflow/issues/12))
--   :sparkles: `MlflowPipelineHook` and `MlflowNodeHook` are now [auto-registered](https://kedro.readthedocs.io/en/latest/extend_kedro/hooks.html#registering-your-hook-implementations-with-kedro) if you use `kedro>=0.16.4` ([#29](https://github.com/Galileo-Galilei/kedro-mlflow/issues/29))
+-   :sparkles: `MlflowPipelineHook` and `MlflowNodeHook` are now [auto-registered](https://kedro.readthedocs.io/en/latest/hooks/introduction.html#registering-your-hook-implementations-with-kedro) if you use `kedro>=0.16.4` ([#29](https://github.com/Galileo-Galilei/kedro-mlflow/issues/29))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   :loud_sound: `kedro-mlflow` has its default logging level set to ``INFO``. This was the default for ``kedro<=0.18.1``. For ``kedro>=0.18.2``, you can change the level in ``logging.yml`` ([#348](https://github.com/Galileo-Galilei/kedro-mlflow/issues/348))
 
+### Fixed
+
+-   :bug: ``kedro-mlflow`` now use the ``package_name`` as experiment name by default if it is not specified. This is done to ensure consistency with the behaviour with no ``mlflow.yml`` file ([#328](https://github.com/Galileo-Galilei/kedro-mlflow/issues/328))
+
 ## [0.11.2] - 2022-08-28
 
 ### Changed

--- a/docs/source/01_introduction/01_introduction.md
+++ b/docs/source/01_introduction/01_introduction.md
@@ -60,7 +60,7 @@ This approach suffers from two main drawbacks:
 On the other hand, ``Mlflow``:
 
 - distinguishes between artifacts (i.e. any data file), metrics (integers that may evolve over time) and parameters. The logging is very straightforward since there is a one-liner function for logging the desired type. This separation makes further manipulation easier.
-- offers a way to configure the logging in a database through the ``mlflow_tracking_uri`` parameter. This database-like logging comes with easy [querying of different runs through a client](https://www.mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient) (for instance "find the most recent run with a metric at least above a given threshold" is immediate with ``Mlflow`` but hacky in ``Kedro``).
+- offers a way to configure the logging in a database through the ``mlflow_tracking_uri`` parameter. This database-like logging comes with easy [querying of different runs through a client](https://www.mlflow.org/docs/latest/python_api/mlflow.client.html#mlflow.client.MlflowClient) (for instance "find the most recent run with a metric at least above a given threshold" is immediate with ``Mlflow`` but hacky in ``Kedro``).
 - [comes with a *User Interface* (UI)](https://mlflow.org/docs/latest/tracking.html#id7) which enable to browse / filter / sort the runs, display graphs of the metrics, render plots... This make the run management much easier than in ``Kedro``.
 - has a command to reproduce exactly the run from a given ``git sha``, [which is not possible in ``Kedro``](https://github.com/quantumblacklabs/kedro/issues/297).
 

--- a/docs/source/02_installation/02_setup.md
+++ b/docs/source/02_installation/02_setup.md
@@ -47,17 +47,17 @@ kedro mlflow init --env=<other-environment>
 
 ### Declaring ``kedro-mlflow`` hooks
 
-``kedro_mlflow`` hooks implementations must be registered with Kedro. There are 2 ways of registering [hooks](https://kedro.readthedocs.io/en/latest/extend_kedro/hooks.html).
+``kedro_mlflow`` hooks implementations must be registered with Kedro. There are 2 ways of registering [hooks](https://kedro.readthedocs.io/en/latest/hooks/introduction.html).
 
 **Note that you must register the hook provided by kedro-mlflow** (``MlflowHook``) to make the plugin work.
 
 #### Declaring hooks through auto-discovery (for `kedro>=0.16.4`) [Default behaviour]
 
-If you use `kedro>=0.16.4`, `kedro-mlflow` hooks are auto-registered automatically by default without any action from your side. You can [disable this behaviour](https://kedro.readthedocs.io/en/latest/extend_kedro/hooks.html#disable-auto-registered-plugins-hooks) in your `settings.py` file.
+If you use `kedro>=0.16.4`, `kedro-mlflow` hooks are auto-registered automatically by default without any action from your side. You can [disable this behaviour](https://kedro.readthedocs.io/en/latest/hooks/introduction.html#disable-auto-registered-plugins-hooks) in your `settings.py` file.
 
 #### Declaring hooks statically in settings.py
 
-If you have turned off plugin automatic registration, you can register its hooks manually by [adding them to ``settings.py``](https://kedro.readthedocs.io/en/latest/extend_kedro/hooks.html#registering-your-hook-implementations-with-kedro):
+If you have turned off plugin automatic registration, you can register its hooks manually by [adding them to ``settings.py``](https://kedro.readthedocs.io/en/latest/hooks/introduction.html#registering-your-hook-implementations-with-kedro):
 
 ```python
 # <your_project>/src/<your_project>/settings.py

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -61,8 +61,39 @@ def test_mlflow_config_in_uninitialized_project(kedro_project, package_name):
     bootstrap_project(kedro_project)
     session = KedroSession.create(project_path=kedro_project, package_name=package_name)
     context = session.load_context()
-    context.mlflow.dict() == {
-        "server": {"mlflow_tracking_uri": None, "credentials": None},
+    assert context.mlflow.dict() == {
+        "server": {
+            "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
+            "credentials": None,
+        },
+        "tracking": {
+            "disable_tracking": {"pipelines": []},
+            "experiment": {"name": "fake_project", "restore_if_deleted": True},
+            "run": {"id": None, "name": None, "nested": True},
+            "params": {
+                "dict_params": {"flatten": False, "recursive": True, "sep": "."},
+                "long_params_strategy": "fail",
+            },
+        },
+        "ui": {"port": "5000", "host": "127.0.0.1"},
+    }
+
+
+def test_mlflow_config_with_no_experiment_name(kedro_project):
+
+    # create empty conf
+    open((kedro_project / "conf" / "base" / "mlflow.yml").as_posix(), mode="w").close()
+
+    bootstrap_project(kedro_project)
+    session = KedroSession.create(
+        project_path=kedro_project, package_name="fake_project"
+    )
+    context = session.load_context()
+    assert context.mlflow.dict() == {
+        "server": {
+            "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
+            "credentials": None,
+        },
         "tracking": {
             "disable_tracking": {"pipelines": []},
             "experiment": {"name": "fake_project", "restore_if_deleted": True},

--- a/tests/framework/hooks/test_hook_log_parameters.py
+++ b/tests/framework/hooks/test_hook_log_parameters.py
@@ -151,6 +151,7 @@ def test_node_hook_logging(
         mlflow_node_hook = MlflowHook()
         mlflow_node_hook.after_context_created(context)  # setup mlflow_config
         mlflow.set_tracking_uri(mlflow_tracking_uri)
+
         with mlflow.start_run():
             mlflow_node_hook.before_pipeline_run(
                 run_params=dummy_run_params,


### PR DESCRIPTION
## Description
 Fix an inconsistency behaviour when between mlflow.yml file was all commented out (use "Default"experiment name) and when the conf was missing (use project name as experiment name)

## Development notes
Change setup to manage a missing key in tracking.experiment.name

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
