### PR TITLE
:bug: Correctly loads the artifact when both artifact_path and run_id are specified in MlflowArtifactDataSet (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   :bug: ``MlflowArtifactDataSet.load()`` now correctly loads the artifact when both ``artifact_path`` and ``run_id`` arguments are specified instead of raising an error ([#362](https://github.com/Galileo-Galilei/kedro-mlflow/issues/362))
+
 ## [0.11.3] - 2022-09-06
 
 ### Changed
@@ -10,7 +14,7 @@
 
 ### Fixed
 
--   :bug: `kedro-mlflow` now use the `package_name` as experiment name by default if it is not specified. This is done to ensure consistency with the behaviour with no `mlflow.yml` file ([#328](https://github.com/Galileo-Galilei/kedro-mlflow/issues/328))
+-   :bug: `kedro-mlflow` now uses the `package_name` as experiment name by default if it is not specified. This is done to ensure consistency with the behaviour with no `mlflow.yml` file ([#328](https://github.com/Galileo-Galilei/kedro-mlflow/issues/328))
 -   :memo: Update broken links to the most recent kedro and mlflow documentation
 
 ## [0.11.2] - 2022-08-28

--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -96,7 +96,7 @@ class MlflowArtifactDataSet(AbstractVersionedDataSet):
                         local_path = Path(self._path)
 
                     artifact_path = (
-                        (self.artifact_path / local_path.name).as_posix()
+                        (self.artifact_path / Path(local_path.name)).as_posix()
                         if self.artifact_path
                         else local_path.name
                     )

--- a/tests/io/artifacts/test_mlflow_artifact_dataset.py
+++ b/tests/io/artifacts/test_mlflow_artifact_dataset.py
@@ -228,6 +228,32 @@ def test_artifact_dataset_load_with_run_id(tmp_path, tracking_uri, df1, df2):
     assert df1.equals(mlflow_csv_dataset.load())
 
 
+@pytest.mark.parametrize("artifact_path", (None, "folder", "folder/subfolder"))
+def test_artifact_dataset_load_with_run_id_and_artifact_path(
+    tmp_path, tracking_uri, df1, artifact_path
+):
+    print("artifact_path", artifact_path)
+    mlflow.set_tracking_uri(tracking_uri.as_uri())
+
+    # save first and retrieve run id
+    mlflow_csv_dataset1 = MlflowArtifactDataSet(
+        data_set=dict(type=CSVDataSet, filepath=(tmp_path / "df1.csv").as_posix()),
+        artifact_path=artifact_path,
+    )
+    with mlflow.start_run():
+        mlflow_csv_dataset1.save(df1)
+        first_run_id = mlflow.active_run().info.run_id
+
+    # same as before, but a closed run_id is specified
+    mlflow_csv_dataset2 = MlflowArtifactDataSet(
+        data_set=dict(type=CSVDataSet, filepath=(tmp_path / "df1.csv").as_posix()),
+        artifact_path=artifact_path,
+        run_id=first_run_id,
+    )
+
+    assert df1.equals(mlflow_csv_dataset2.load())
+
+
 @pytest.mark.parametrize("artifact_path", [None, "partitioned_data"])
 def test_partitioned_dataset_save_and_reload(
     tmp_path, tracking_uri, artifact_path, df1, df2


### PR DESCRIPTION
## Description
Close #362

## Development notes

Update MlflowArtifactDataset.load to use Path() object instead of str.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
