### PR TITLE
:bug: Force downloading locally artifacts from a run_id af ignore to specified filepath (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   :bug: `MlflowArtifactDataSet.load()` now correctly loads the artifact when both `artifact_path` and `run_id` arguments are specified. Previous fix in ``0.11.4`` did not work because when the file already exist locally, mlflow did not download it again so tests were incorrectly passing.   ([#362](https://github.com/Galileo-Galilei/kedro-mlflow/issues/362))
+
 ## [0.11.4] - 2022-10-04
 
 ### Fixed

--- a/tests/io/artifacts/test_mlflow_artifact_dataset.py
+++ b/tests/io/artifacts/test_mlflow_artifact_dataset.py
@@ -243,7 +243,9 @@ def test_artifact_dataset_load_with_run_id_and_artifact_path(
     with mlflow.start_run():
         mlflow_csv_dataset1.save(df1)
         first_run_id = mlflow.active_run().info.run_id
-
+        (
+            tmp_path / "df1.csv"
+        ).unlink()  # we need to delete the data, else it is automatically reused instead of downloading
     # same as before, but a closed run_id is specified
     mlflow_csv_dataset2 = MlflowArtifactDataSet(
         data_set=dict(type=CSVDataSet, filepath=(tmp_path / "df1.csv").as_posix()),
@@ -252,6 +254,9 @@ def test_artifact_dataset_load_with_run_id_and_artifact_path(
     )
 
     assert df1.equals(mlflow_csv_dataset2.load())
+    assert df1.equals(
+        mlflow_csv_dataset2.load()
+    )  # we check idempotency. When using a local tracking uri, mlflow does not downlaod in a tempfolder, so moving the folder alter the mlflow run
 
 
 @pytest.mark.parametrize("artifact_path", [None, "partitioned_data"])


### PR DESCRIPTION
## Description

Close #362

## Development notes

Do not specify fodler for download_artifacts, but download in temp folder and then copy to the right destination. 

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
