### PR TITLE
Add the ability to configure mlflow_registry_uri in mlflow.yml (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- :sparkles: Added an extra ``server.mlflow_registry_uri`` key in ``mlflow.yml`` to set the mlflow registry uri. ([#260](https://github.com/Galileo-Galilei/kedro-mlflow/issues/260))
+
 ### Fixed
 
 -   :bug: `MlflowArtifactDataSet.load()` now correctly loads the artifact when both `artifact_path` and `run_id` arguments are specified. Previous fix in ``0.11.4`` did not work because when the file already exist locally, mlflow did not download it again so tests were incorrectly passing ([#362](https://github.com/Galileo-Galilei/kedro-mlflow/issues/362))
 
 ### Removed
 
--   :fire: :boom: Remove ``reload_kedro_mlflow`` line magic for notebook because kedro will deprecate the entrypoint in 0.18.3. It is still possible to access the mlflow client associated to the configuration in a notebook with ``context.mlflow.server._mlflow_client`` ([#349](https://github.com/Galileo-Galilei/kedro-mlflow/issues/349)). This is not considered as a breaking change since apparently no one uses it according to a [discussion with kedro's team](https://github.com/kedro-org/kedro/issues/878#issuecomment-1226545251)
+-   :fire: :boom: Remove ``reload_kedro_mlflow`` line magic for notebook because kedro will deprecate the entrypoint in 0.18.3. It is still possible to access the mlflow client associated to the configuration in a notebook with ``context.mlflow.server._mlflow_client`` ([#349](https://github.com/Galileo-Galilei/kedro-mlflow/issues/349)). This is not considered as a breaking change since apparently no one uses it according to a [discussion with kedro's team](https://github.com/kedro-org/kedro/issues/878#issuecomment-1226545251).
 
 ## [0.11.4] - 2022-10-04
 

--- a/docs/source/04_experimentation_tracking/01_configuration.md
+++ b/docs/source/04_experimentation_tracking/01_configuration.md
@@ -32,6 +32,13 @@ server:
 
 This is the **only mandatory key in the `mlflow.yml` file**, but there are many others described hereafter that provide fine-grained control on your mlflow setup.
 
+You can also specify the registry uri:
+
+```yaml
+server:
+  mlflow_registry_uri: registry.db
+```
+
 You can also specify some environment variables needed by mlflow (e.g `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) in the credentials and specify them in the `mlflow.yml`. Any key specified will be automatically exported as environment variables.
 
 Your `credentials.yml` will look as follows:

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -18,6 +18,7 @@
 
 server:
   mlflow_tracking_uri: null # if null, will use mlflow.get_tracking_uri() as a default
+  mlflow_registry_uri: null # if null, mlflow_tracking_uri will be used as mlflow default
   credentials: null  # must be a valid key in credentials.yml which refers to a dict of sensitive mlflow environment variables (password, tokens...). See top of the file.
 
 tracking:

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -27,6 +27,7 @@ def test_mlflow_config_default(kedro_project):
     dict_config = dict(
         server=dict(
             mlflow_tracking_uri="mlruns",
+            mlflow_registry_uri=None,
             credentials=None,
         ),
         tracking=dict(
@@ -64,6 +65,7 @@ def test_mlflow_config_in_uninitialized_project(kedro_project, package_name):
     assert context.mlflow.dict() == {
         "server": {
             "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
+            "mlflow_registry_uri": None,
             "credentials": None,
         },
         "tracking": {
@@ -92,6 +94,7 @@ def test_mlflow_config_with_no_experiment_name(kedro_project):
     assert context.mlflow.dict() == {
         "server": {
             "mlflow_tracking_uri": (kedro_project / "mlruns").as_uri(),
+            "mlflow_registry_uri": None,
             "credentials": None,
         },
         "tracking": {
@@ -196,6 +199,7 @@ def test_mlflow_config_with_templated_config_loader(fake_project):
     dict_config = dict(
         server=dict(
             mlflow_tracking_uri="${mlflow_tracking_uri}",
+            mlflow_registry_uri=None,
             credentials=None,
         ),
         tracking=dict(


### PR DESCRIPTION
## Description

First step for #260

## Development notes

- add an ``mlflow_registry_uri`` key in ``KedroMlflowConfig`` and ``mlflow.yml``

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
