### PR TITLE
:bug: Use '__default__' as the mlflow run name when the pipeline is not specified in 'kedro run' command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,25 @@
 exclude: ^kedro_mlflow/template/project/run.py$
 repos:
     - repo: https://github.com/psf/black
-      rev: 22.3.0
+      rev: 22.12.0
       hooks:
           - id: black
             language_version: python3.9
     - repo: https://github.com/timothycrosley/isort
-      rev: 5.10.1
+      rev: 5.11.1
       hooks:
           - id: isort
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 4.0.1
+    - repo: https://github.com/pycqa/flake8
+      rev: 5.0.4
       hooks:
           - id: flake8
     - repo: https://github.com/asottile/blacken-docs
-      rev: v1.11.0
+      rev: v1.12.1
       hooks:
         - id: blacken-docs
-          additional_dependencies: [black==21.10b0]
+          additional_dependencies: [black==22.12.0]
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.0.1
+      rev: v4.4.0
       hooks:
           - id: check-merge-conflict
           - id: debug-statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- :bug: Use  ``__default__`` as a run name if the pipeline is not specified in the ``kedro run`` commmand to avoid empty names ([#392](https://github.com/Galileo-Galilei/kedro-mlflow/issues/392))
+
 ## [0.11.6] - 2023-01-09
 
 ### Changed

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -224,7 +224,9 @@ class MlflowHook:
             )
 
             run_name = (
-                self.mlflow_config.tracking.run.name or run_params["pipeline_name"]
+                self.mlflow_config.tracking.run.name
+                or run_params["pipeline_name"]
+                or "__default__"
             )
 
             if self._already_active_mlflow:

--- a/tests/framework/hooks/test_run_name.py
+++ b/tests/framework/hooks/test_run_name.py
@@ -1,0 +1,52 @@
+import mlflow
+import pytest
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import bootstrap_project
+from kedro.io import DataCatalog
+from kedro.pipeline import Pipeline
+
+from kedro_mlflow.framework.hooks import MlflowHook
+
+
+@pytest.mark.parametrize(
+    "pipeline_name,expected_mlflow_run_name",
+    [
+        ("my_cool_pipeline", "my_cool_pipeline"),
+        ("__default__", "__default__"),
+        (None, "__default__"),
+    ],
+)
+def test_pipeline_use_pipeline_name_as_run_name(
+    kedro_project, pipeline_name, expected_mlflow_run_name
+):
+
+    dummy_run_params = {
+        "run_id": "1234",
+        "project_path": "path/to/project",
+        "env": "local",
+        "kedro_version": "X.Y.Z",
+        "tags": [],
+        "from_nodes": [],
+        "to_nodes": [],
+        "node_names": [],
+        "from_inputs": [],
+        "load_versions": [],
+        "pipeline_name": pipeline_name,
+        "extra_params": [],
+    }
+
+    bootstrap_project(kedro_project)
+    with KedroSession.create(
+        project_path=kedro_project,
+    ) as session:
+        context = session.load_context()
+
+        mlflow_node_hook = MlflowHook()
+        mlflow_node_hook.after_context_created(context)
+        mlflow_node_hook.before_pipeline_run(
+            run_params=dummy_run_params, pipeline=Pipeline([]), catalog=DataCatalog()
+        )
+
+        assert (
+            mlflow.active_run().data.tags["mlflow.runName"] == expected_mlflow_run_name
+        )


### PR DESCRIPTION
## Description
Fix #392

## Development notes
If pipeline_name is None in the hook, use __default instead

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
