### PR TITLE
Add a run_name argument in mlflow modelify command and use 'modelify' as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 -   :sparkles: Added support for Mlflow 2.0 ([#390](https://github.com/Galileo-Galilei/kedro-mlflow/issues/390))
 
+-   :sparkels: The ``modelify`` command now accepts a ``--run-name`` to specifiy the run name where the model is logged ([#408](https://github.com/Galileo-Galilei/kedro-mlflow/issues/408))
 ### Fixed
 
 -   :memo: Update incorrect documentation about model registry with local relative filepath ([#400](https://github.com/Galileo-Galilei/kedro-mlflow/issues/400))
@@ -12,6 +13,8 @@
 -   :bug: The ``modelify`` command now creates a conda environment based on your environment  python and kedro versions instead of hardcoded ``python=3.7`` and ``kedro=0.16.5`` ([#405](https://github.com/Galileo-Galilei/kedro-mlflow/issues/405))
 
 -   :bug: The ``modelify`` command now uses correctly the ``--pip-requirements`` argument instead of raising an error ([#405](https://github.com/Galileo-Galilei/kedro-mlflow/issues/405))
+
+-   :bug: The ``modelify`` command now uses ``modelify``  as a default run name ([#408](https://github.com/Galileo-Galilei/kedro-mlflow/issues/408))
 
 ## [0.11.7] - 2023-01-28
 

--- a/docs/source/05_pipeline_serving/03_cli_modelify.md
+++ b/docs/source/05_pipeline_serving/03_cli_modelify.md
@@ -7,5 +7,5 @@ kedro mlflow modelify --pipeline=<your-pipeline> --input-name <name-in-catalog-o
 ```
 
 This command will create a new run with an artifact named ``model``. Open the user interface with ``kedro mlflow ui`` to check the result. You can also:
-- specify the run id in which you want to log the pipeline with the ``--run-id`` argument
+- specify the run id in which you want to log the pipeline with the ``--run-id`` argument, and its name with the --run-name argument.
 - pass almost all arguments accepted by [``mlflow.pyfunc.log_model``](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model), see the list of all accepted arguments in the [API documentation](https://kedro-mlflow.readthedocs.io/en/stable/source/08_API/kedro_mlflow.framework.cli.html#modelify)

--- a/docs/source/07_python_objects/04_CLI.md
+++ b/docs/source/07_python_objects/04_CLI.md
@@ -33,3 +33,25 @@ kedro mlflow ui --port=5002
 ```
 
 will open the ui on port 5002.
+
+
+## ``modelify``
+
+``kedro mlflow modelify``: this command converts a kedro pipeline to a mlflow model and logs it in mlflow. It enables distributing the kedro pipeline as a standalone model and leverages all mlflow serving capabilities (as an API).
+
+`modelify` accepts the following arguments :
+
+- ``--pipeline``, ``-p``: The name of the kedro pipeline name registered in ``pipeline_registry.py`` that you want to convert to a mlflow model.
+- ``--input-name``, ``-i``: The name of the kedro dataset (in ``catalog.yml``)  which is the input of your pipeline. It contains the data to predict on.  
+- ``--infer-signature`` :  A boolean which indicates if the signature of the input data should be inferred for mlflow or not.
+- ``--infer-input-example`` : A boolean which indicates if the input_example of the input data should be inferred for mlflow or not
+- ``--run-id``, ``-r`` : The id of the mlflow run where the model will be logged. If unspecified, the command creates a new run.
+- ``--run-name``: The name of the mlflow run where the model will be logged. Defaults to "modelify".
+- ``--copy-mode`` : The copy mode to use when replacing each dataset by a ``MemoryDataSet``. Either a string (applied all datasets) or a dict mapping each dataset to a copy_mode.
+- ``--artifact-path" : The artifact path of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--code-path`` : The code path of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--conda-env`` : "The conda environment of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--registered-model-name`` : The registered_model_name of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--await-registration-for``: The await_registration_for of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model*
+- ``--pip-requirements`` : The pip_requirements of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--extra-pip-requirements`` : The extra_pip_requirements of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -234,6 +234,12 @@ def run():
     help="The id of the mlflow run where the model will be logged. If unspecified, the command creates a new run.",
 )
 @click.option(
+    "--run-name",
+    required=False,
+    default="modelify",
+    help="The name of the mlflow run where the model will be logged. Defaults to 'modelify'.",
+)
+@click.option(
     "--copy-mode",
     required=False,
     default="deepcopy",
@@ -288,6 +294,7 @@ def modelify(
     flag_infer_signature: Optional[bool],
     flag_infer_input_example: Optional[bool],
     run_id: Optional[str],
+    run_name: Optional[str],
     copy_mode: Optional[Union[str, Dict[str, str]]],
     artifact_path: str,
     code_path: str,
@@ -373,7 +380,7 @@ def modelify(
 
             log_model_kwargs["conda_env"] = conda_env
 
-            with mlflow.start_run(run_id=run_id):
+            with mlflow.start_run(run_id=run_id, run_name=run_name):
                 mlflow.pyfunc.log_model(**log_model_kwargs)
                 run_id = mlflow.active_run().info.run_id
                 LOGGER.info(f"Model successfully logged in run '{run_id}'")


### PR DESCRIPTION
## Description
Close #408 

## Development notes
- update documentation for the ``modelify`` command
- add run name argument 

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
