### PR TITLE
:boom: :sparkles: Set KedroPipelineModel default copy_mode to 'assign' (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- :sparkles: Add support for python 3.11 ([#450,rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/450))
+- :sparkles: Add support for python 3.11 ([#450, rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/450))
 - :boom: :recycle: Rename the following ``DataSets`` with the ``Dataset`` suffix (without capitalized ``S``) to match new kedro conventions from ``kedro>=0.19`` and onwards ([#439, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/439)):
   - ``MlflowArtifactDataSet``->``MlflowArtifactDataset``
   - ``MlflowAbstractModelDataSet``->``MlflowAbstractModelDataset``
@@ -10,9 +10,11 @@
   - ``MlflowMetricDataSet``->``MlflowMetricDataset``
   - ``MlflowMetricHistoryDataSet``->``MlflowMetricHistoryDataset``
   - ``MlflowMetricsDataSet``->``MlflowMetricsDataset``
-- :boom: :recycle: Rename the following ``DataSets`` to make their use more explicit, and use the ``Dataset`` suffix:
+- :boom: :recycle: Rename the following ``DataSets`` to make their use more explicit, and use the ``Dataset`` suffix ([#465, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/465)):
   -  ``MlflowModelLoggerDataSet``->``MlflowModelTrackingDataset``
   -  ``MlflowModelSaverDataSet``->``MlflowModelLocalFileSystemDataset``
+
+- :boom: :sparkles: Change default ``copy_mode``  to ``"assign"`` in ``KedroPipelineModel`` because this is the most efficient setup (and usually the desired one) when serving a Kedro ``Pipeline`` as a Mlflow model. This is different from Kedro's default which is to deepcopy the dataset ([#463, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/463)).
 
 ## [0.11.10] - 2023-10-03
 

--- a/docs/source/05_pipeline_serving/02_custom_kedro_pipeline_model.md
+++ b/docs/source/05_pipeline_serving/02_custom_kedro_pipeline_model.md
@@ -26,7 +26,7 @@ input_name = "instances"
 input_data = catalog.load(input_name)
 model_signature = infer_signature(model_input=input_data)
 
-# you can optionnally pass other arguments, like the "copy_mode" to be used for each dataset
+# you can optionally pass other arguments, like the "copy_mode" to be used for each dataset
 kedro_pipeline_model = KedroPipelineModel(
     pipeline=pipeline, catalog=catalog, input_name=input_name
 )

--- a/docs/source/07_python_objects/03_Pipelines.md
+++ b/docs/source/07_python_objects/03_Pipelines.md
@@ -66,10 +66,10 @@ mlflow.pyfunc.log_model(
 )
 ```
 
-It is also possible to pass arguments to `KedroPipelineModel` to specify the runner or the copy_mode of MemoryDataset for the inference Pipeline. This may be faster especially for  compiled model (e.g keras, tensorflow), and more suitable for an API serving pattern.
+It is also possible to pass arguments to `KedroPipelineModel` to specify the runner or the copy_mode of ``MemoryDataset`` for the inference ``Pipeline``. This may be faster especially for compiled model (e.g keras, tensorflow...), and more suitable for an API serving pattern. Since ``kedro-mlflow==0.12.0``, ``copy_mode="assign"`` has become the default.
 
 ```python
 KedroPipelineModel(pipeline=pipeline_training, catalog=catalog, copy_mode="assign")
 ```
 
-Available `copy_mode` are "assign", "copy" and "deepcopy". It is possible to pass a dictionary to specify different copy mode fo each dataset.
+Available `copy_mode` are ``assign``, ``copy`` and ``deepcopy``. It is possible to pass a dictionary to specify different copy mode fo each dataset.

--- a/docs/source/07_python_objects/04_CLI.md
+++ b/docs/source/07_python_objects/04_CLI.md
@@ -34,7 +34,6 @@ kedro mlflow ui --port=5002
 
 will open the ui on port 5002.
 
-
 ## ``modelify``
 
 ``kedro mlflow modelify``: this command converts a kedro pipeline to a mlflow model and logs it in mlflow. It enables distributing the kedro pipeline as a standalone model and leverages all mlflow serving capabilities (as an API).
@@ -46,9 +45,9 @@ will open the ui on port 5002.
 - ``--infer-signature`` :  A boolean which indicates if the signature of the input data should be inferred for mlflow or not.
 - ``--infer-input-example`` : A boolean which indicates if the input_example of the input data should be inferred for mlflow or not
 - ``--run-id``, ``-r`` : The id of the mlflow run where the model will be logged. If unspecified, the command creates a new run.
-- ``--run-name``: The name of the mlflow run where the model will be logged. Defaults to "modelify".
-- ``--copy-mode`` : The copy mode to use when replacing each dataset by a ``MemoryDataset``. Either a string (applied all datasets) or a dict mapping each dataset to a copy_mode.
-- ``--artifact-path" : The artifact path of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+- ``--run-name``: The name of the mlflow run where the model will be logged. Defaults to ``"modelify"``.
+- ``--copy-mode`` : The copy mode to use when replacing each dataset by a ``MemoryDataset``. Either a string (applied all datasets) or a dict mapping each dataset to a ``copy_mode``.
+- ``--artifact-path"`` : The artifact path of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
 - ``--code-path`` : The code path of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
 - ``--conda-env`` : "The conda environment of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
 - ``--registered-model-name`` : The registered_model_name of mlflow.pyfunc.log_model, see https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model

--- a/kedro_mlflow/mlflow/kedro_pipeline_model.py
+++ b/kedro_mlflow/mlflow/kedro_pipeline_model.py
@@ -19,7 +19,7 @@ class KedroPipelineModel(PythonModel):
         catalog: DataCatalog,
         input_name: str,
         runner: Optional[AbstractRunner] = None,
-        copy_mode: Optional[Union[Dict[str, str], str]] = None,
+        copy_mode: Optional[Union[Dict[str, str], str]] = "assign",
     ):
         """[summary]
 
@@ -37,11 +37,12 @@ class KedroPipelineModel(PythonModel):
             copy_mode (Optional[Union[Dict[str,str], str]]):
             The copy_mode of each DataSet of the catalog
             when reconstructing the DataCatalog in memory.
+            The default is "assign".
             You can pass either:
                 - None to use Kedro default mode for each dataset
                 - a single string ("deepcopy", "copy" and "assign")
                 to apply to all datasets
-                - a dictionnary with (dataset name, copy_mode) key/values
+                - a dictionary with (dataset name, copy_mode) key/values
                 pairs. The associated mode must be a valid kedro mode
                 ("deepcopy", "copy" and "assign") for each. Defaults to None.
         """


### PR DESCRIPTION
## Description
Close #463

## Development notes
- Set KedroPipelineModel default copy_mode to 'assign'

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
-  N/A Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
