### PR TITLE
Refactor codes and tests to match kedro==0.19 conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - :boom: :recycle: Rename the following ``DataSets`` to make their use more explicit, and use the ``Dataset`` suffix ([#465, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/465)):
   -  ``MlflowModelLoggerDataSet``->``MlflowModelTrackingDataset``
   -  ``MlflowModelSaverDataSet``->``MlflowModelLocalFileSystemDataset``
-
 - :boom: :sparkles: Change default ``copy_mode``  to ``"assign"`` in ``KedroPipelineModel`` because this is the most efficient setup (and usually the desired one) when serving a Kedro ``Pipeline`` as a Mlflow model. This is different from Kedro's default which is to deepcopy the dataset ([#463, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/463)).
+- :boom: :recycle: ``MlflowArtifactDataset.__init__`` method ``data_set`` argument is renamed ``dataset`` to match new Kedro conventions ().
 
 ## [0.11.10] - 2023-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,24 @@
 
 ## [Unreleased]
 
+### Added
+
 - :sparkles: Add support for python 3.11 ([#450, rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/450))
+
+### Changed
+
+- :boom: :sparkles: Change default ``copy_mode``  to ``"assign"`` in ``KedroPipelineModel`` because this is the most efficient setup (and usually the desired one) when serving a Kedro ``Pipeline`` as a Mlflow model. This is different from Kedro's default which is to deepcopy the dataset ([#463, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/463)).
+- :boom: :recycle: ``MlflowArtifactDataset.__init__`` method ``data_set`` argument is renamed ``dataset`` to match new Kedro conventions ([#391](https://github.com/Galileo-Galilei/kedro-mlflow/pull/391)).
 - :boom: :recycle: Rename the following ``DataSets`` with the ``Dataset`` suffix (without capitalized ``S``) to match new kedro conventions from ``kedro>=0.19`` and onwards ([#439, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/439)):
   - ``MlflowArtifactDataSet``->``MlflowArtifactDataset``
   - ``MlflowAbstractModelDataSet``->``MlflowAbstractModelDataset``
   - ``MlflowModelRegistryDataSet``->``MlflowModelRegistryDataset``
   - ``MlflowMetricDataSet``->``MlflowMetricDataset``
   - ``MlflowMetricHistoryDataSet``->``MlflowMetricHistoryDataset``
-  - ``MlflowMetricsDataSet``->``MlflowMetricsDataset``
-- :boom: :recycle: Rename the following ``DataSets`` to make their use more explicit, and use the ``Dataset`` suffix ([#465, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/465)):
-  -  ``MlflowModelLoggerDataSet``->``MlflowModelTrackingDataset``
-  -  ``MlflowModelSaverDataSet``->``MlflowModelLocalFileSystemDataset``
-- :boom: :sparkles: Change default ``copy_mode``  to ``"assign"`` in ``KedroPipelineModel`` because this is the most efficient setup (and usually the desired one) when serving a Kedro ``Pipeline`` as a Mlflow model. This is different from Kedro's default which is to deepcopy the dataset ([#463, ShubhamZoro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/463)).
-- :boom: :recycle: ``MlflowArtifactDataset.__init__`` method ``data_set`` argument is renamed ``dataset`` to match new Kedro conventions ().
+- :boom: :recycle: Rename the following ``DataSets`` to make their use more explicit, and use the ``Dataset`` suffix:
+  - ``MlflowModelLoggerDataSet``->``MlflowModelTrackingDataset`` ([#391](https://github.com/Galileo-Galilei/kedro-mlflow/pull/391))
+  - ``MlflowModelSaverDataSet``->``MlflowModelLocalFileSystemDataset`` ([#391](https://github.com/Galileo-Galilei/kedro-mlflow/pull/391))
+  - ``MlflowMetricsDataSet``->``MlflowMetricsHistoryDataset`` ([#440](https://github.com/Galileo-Galilei/kedro-mlflow/pull/440))
 
 ## [0.11.10] - 2023-10-03
 
@@ -334,7 +339,7 @@
     -   `get_mlflow_config` now works in interactive mode if `load_context` is called  with a path different from the working directory ([#30](https://github.com/Galileo-Galilei/kedro-mlflow/issues/30))
     -   ``kedro_mlflow`` now works fine with ``kedro jupyter notebook`` independently of the working directory ([#64](https://github.com/Galileo-Galilei/kedro-mlflow/issues/64))
     -   You can use global variables in `mlflow.yml` which is now properly parsed if you use a `TemplatedConfigLoader` ([#72](https://github.com/Galileo-Galilei/kedro-mlflow/issues/72))
--   :bug: `MlflowMetricsDataset` now saves in the specified `run_id` instead of the current one when the prefix is not specified ([#62](https://github.com/Galileo-Galilei/kedro-mlflow/issues/62))
+-   :bug: `MlflowMetricsHistoryDataset` now saves in the specified `run_id` instead of the current one when the prefix is not specified ([#62](https://github.com/Galileo-Galilei/kedro-mlflow/issues/62))
 -   :memo: Other bug fixes and documentation improvements ([#6](https://github.com/Galileo-Galilei/kedro-mlflow/issues/6), [#99](https://github.com/Galileo-Galilei/kedro-mlflow/issues/99))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The documentation contains:
 
 Some frequently asked questions on more advanced features:
 
-- You want to log additional metrics to the run? -> [Try ``MlflowMetricsDataset``](https://kedro-mlflow.readthedocs.io/en/stable/source/04_experimentation_tracking/05_version_metrics.html) !
+- You want to log additional metrics to the run? -> [Try ``MlflowMetricsHistoryDataset``](https://kedro-mlflow.readthedocs.io/en/stable/source/04_experimentation_tracking/05_version_metrics.html) !
 - You want to log nice dataviz of your pipeline that you register with ``MatplotlibWriter``? -> [Try ``MlflowArtifactDataset`` to log any local files (.png, .pkl, .csv...) *automagically*](https://kedro-mlflow.readthedocs.io/en/stable/source/04_experimentation_tracking/03_version_datasets.html)!
 - You want to create easily an API to share your awesome model to anyone? -> [See if ``pipeline_ml_factory`` can fit your needs](https://github.com/Galileo-Galilei/kedro-mlflow/issues/16)
 - You want to do something that is not straigthforward with current implementation? Open an issue, and let's see what happens!

--- a/docs/source/01_introduction/02_motivation.md
+++ b/docs/source/01_introduction/02_motivation.md
@@ -41,7 +41,7 @@ Above implementations have the advantage of being very straightforward and *mlfl
 | Logging parameters        | ``mlflow.yml``  | ``MlflowHook``                                             |
 | Logging artifacts         | ``catalog.yml`` | ``MlflowArtifactDataset``                                  |
 | Logging models            | ``catalog.yml`` | `MlflowModelTrackingDataset` and `MlflowModelLocalFileSystemDataset` |
-| Logging metrics           | ``catalog.yml`` | ``MlflowMetricsDataset``                                   |
+| Logging metrics           | ``catalog.yml`` | ``MlflowMetricsHistoryDataset``                                   |
 | Logging Pipeline as model | ``hooks.py``    | ``KedroPipelineModel`` and ``pipeline_ml_factory``         |
 
 `kedro-mlflow` does not currently provide interface to set tags outside a Kedro ``Pipeline``. Some of above decisions are subject to debate and design decisions (for instance, metrics are often updated in a loop during each epoch / training iteration and it does not always make sense to register the metric between computation steps, e.g. as a an I/O operation after a node run).

--- a/docs/source/02_installation/03_migration_guide.md
+++ b/docs/source/02_installation/03_migration_guide.md
@@ -101,7 +101,7 @@ Replace the following entries:
 | old                                     | new                                               |
 | :-------------------------------------- | :------------------------------------------------ |
 | `kedro_mlflow.io.MlflowArtifactDataset` | `kedro_mlflow.io.artifacts.MlflowArtifactDataset` |
-| `kedro_mlflow.io.MlflowMetricsDataset`  | `kedro_mlflow.io.metrics.MlflowMetricsDataset`    |
+| `kedro_mlflow.io.MlflowMetricsHistoryDataset`  | `kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset`    |
 
 ### Hooks
 

--- a/docs/source/03_getting_started/02_first_steps.md
+++ b/docs/source/03_getting_started/02_first_steps.md
@@ -141,7 +141,7 @@ example_iris_data:
 
 example_model:
   type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-  data_set:
+  dataset:
     type: pickle.PickleDataset
     filepath: data/06_models/trained_model.pkl
 ```

--- a/docs/source/04_experimentation_tracking/03_version_datasets.md
+++ b/docs/source/04_experimentation_tracking/03_version_datasets.md
@@ -29,7 +29,7 @@ You can change it to:
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/LOCAL/destination/file.csv # must be a local file, wherever you want to log the data in the end
 ```
@@ -40,19 +40,19 @@ and this dataset will be automatically versioned in each pipeline execution.
 
 ### Can I pass extra parameters to the ``MlflowArtifactDataset`` for finer control?
 
-The ``MlflowArtifactDataset`` takes a ``data_set`` argument which is a python dictionary passed to the ``__init__`` method of the dataset declared in ``type``. It means that you can pass any argument accepted by the underlying dataset in this dictionary. If you want to pass ``load_args`` and ``save_args`` in the previous example, add them in the ``data_set`` argument:
+The ``MlflowArtifactDataset`` takes a ``dataset`` argument which is a python dictionary passed to the ``__init__`` method of the dataset declared in ``type``. It means that you can pass any argument accepted by the underlying dataset in this dictionary. If you want to pass ``load_args`` and ``save_args`` in the previous example, add them in the ``dataset`` argument:
 
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv
         load_args:
             sep: ;
         save_args:
             sep: ;
-        # ... any other valid arguments for data_set
+        # ... any other valid arguments for dataset
 ```
 
 ### Can I use the ``MlflowArtifactDataset`` in interactive mode?
@@ -64,7 +64,7 @@ from kedro_mlflow.io.artifacts import MlflowArtifactDataset
 from kedro_datasets.pandas import CSVDataset
 
 csv_dataset = MlflowArtifactDataSet(
-    data_set={
+    dataset={
         "type": CSVDataset,  # either a string "pandas.CSVDataset" or the class
         "filepath": r"/path/to/a/local/destination/file.csv",
     }
@@ -90,7 +90,7 @@ The ``MlflowArtifactDataset`` has an extra attribute ``run_id`` which specifies 
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv  # must be a local filepath, no matter what is your actual mlflow storage (S3 or other)
     run_id: 13245678910111213  # a valid mlflow run to log in. If None, default to active run
@@ -105,7 +105,7 @@ You may want to reuse th artifact of a previous run to reuse it in another one, 
 ```yaml
 my_dataset_to_reload:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv # must be a local filepath, no matter what is your actual mlflow storage (S3 or other)
     run_id: 13245678910111213  # a valid mlflow run with the existing artifact. It must be named "file.csv"
@@ -120,7 +120,7 @@ With below example, the artifact will be logged in mlflow within a `reporting` f
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv
     artifact_path: reporting  # relative path where the remote artifact must be stored. if None, saved in root folder.

--- a/docs/source/04_experimentation_tracking/04_version_models.md
+++ b/docs/source/04_experimentation_tracking/04_version_models.md
@@ -59,7 +59,7 @@ If you want to save your model both locally and remotely within the same run, yo
 ```yaml
 sklearn_model:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: kedro_mlflow.io.models.MlflowModelLocalFileSystemDataset
         flavor: mlflow.sklearn
         filepath: data/06_models/sklearn_model

--- a/docs/source/04_experimentation_tracking/05_version_metrics.md
+++ b/docs/source/04_experimentation_tracking/05_version_metrics.md
@@ -9,7 +9,7 @@ MLflow defines a metric as "a (key, value) pair, where the value is numeric". Ea
 `kedro-mlflow` introduces 3 ``AbstractDataset`` to manage metrics:
 - ``MlflowMetricDataset`` which can log a float as a metric
 - ``MlflowMetricHistoryDataset`` which can log the evolution over time of a given metric, e.g. a list or a dict of float.
-- ``MlflowMetricsDataset``. It is a wrapper around a dictionary with metrics which is returned by node and log metrics in MLflow.
+- ``MlflowMetricsHistoryDataset``. It is a wrapper around a dictionary with metrics which is returned by node and log metrics in MLflow.
 
 ### Saving a single float as a metric with ``MlflowMetricDataset``
 
@@ -148,13 +148,13 @@ my_model_metric:
         mode: ... # OPTIONAL: "list" by default, one of {"list", "dict", "history"}
 ```
 
-### Saving several metrics with their entire history with ``MlflowMetricsDataset``
+### Saving several metrics with their entire history with ``MlflowMetricsHistoryDataset``
 
 Since it is an ``AbstractDataset``, it can be used with the YAML API. You can define it in your ``catalog.yml`` as:
 
 ```yaml
 my_model_metrics:
-    type: kedro_mlflow.io.metrics.MlflowMetricsDataset
+    type: kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset
 ```
 
 You can provide a prefix key, which is useful in situations like when you have multiple nodes producing metrics with the same names which you want to distinguish. If you are using the ``v``, it will handle that automatically for you by giving as prefix metrics data set name. In the example above the prefix would be ``my_model_metrics``.
@@ -163,7 +163,7 @@ Let's look at an example with custom prefix:
 
 ```yaml
 my_model_metrics:
-    type: kedro_mlflow.io.metrics.MlflowMetricsDataset
+    type: kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset
     prefix: foo
 ```
 
@@ -179,7 +179,7 @@ def metrics_node() -> Dict[str, Union[float, List[float]]]:
     }
 ```
 
-As you can see above, ``kedro_mlflow.io.metrics.MlflowMetricsDataset`` can take metrics as:
+As you can see above, ``kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset`` can take metrics as:
 
 - ``Dict[str, key]``
 - ``List[Dict[str, key]]``
@@ -188,7 +188,7 @@ To store metrics we need to define metrics dataset in Kedro Catalog:
 
 ```yaml
 my_model_metrics:
-    type: kedro_mlflow.io.metrics.MlflowMetricsDataset
+    type: kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset
 ```
 
 Within a kedro run, the ``MlflowHook`` will automatically prefix the metrics datasets with their name in the catalog. In our example, the metrics will be stored in Mlflow with the following keys: ``my_model_metrics.metric1``, ``my_model_metrics.metric2``.
@@ -197,7 +197,7 @@ It is also prossible to provide a prefix manually:
 
 ```yaml
 my_model_metrics:
-    type: kedro_mlflow.io.metrics.MlflowMetricsDataset
+    type: kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset
     prefix: foo
 ```
 

--- a/docs/source/07_python_objects/01_DataSets.md
+++ b/docs/source/07_python_objects/01_DataSets.md
@@ -7,7 +7,7 @@
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv
 ```
@@ -17,14 +17,14 @@ or with additional parameters:
 ```yaml
 my_dataset_to_version:
     type: kedro_mlflow.io.artifacts.MlflowArtifactDataset
-    data_set:
+    dataset:
         type: pandas.CSVDataset  # or any valid kedro DataSet
         filepath: /path/to/a/local/destination/file.csv
         load_args:
             sep: ;
         save_args:
             sep: ;
-        # ... any other valid arguments for data_set
+        # ... any other valid arguments for dataset
     run_id: 13245678910111213  # a valid mlflow run to log in. If None, default to active run
     artifact_path: reporting  # relative path where the artifact must be stored. if None, saved in root folder.
 ```
@@ -36,7 +36,7 @@ from kedro_mlflow.io.artifacts import MlflowArtifactDataset
 from kedro_datasets.pandas import CSVDataset
 
 csv_dataset = MlflowArtifactDataset(
-    data_set={"type": CSVDataset, "filepath": r"/path/to/a/local/destination/file.csv"}
+    dataset={"type": CSVDataset, "filepath": r"/path/to/a/local/destination/file.csv"}
 )
 csv_dataset.save(data=pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
 ```

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -113,7 +113,7 @@ class MlflowHook:
                 experiment_name = context._package_name
                 if experiment_name is None:
                     # context._package_name may be None if the session is created interactively
-                    metadata = _get_project_metadata(context._project_path)
+                    metadata = _get_project_metadata(context.project_path)
                     experiment_name = metadata.package_name
                 mlflow_config.tracking.experiment.name = experiment_name
 
@@ -140,25 +140,25 @@ class MlflowHook:
     ):
         # we use this hooks to modif "MlflowmetricsDataset" to ensure consistency
         # of the metric name with the catalog name
-        for name, dataset in catalog._data_sets.items():
+        for name, dataset in catalog._datasets.items():
             if isinstance(dataset, MlflowMetricsDataset) and dataset._prefix is None:
                 if dataset._run_id is not None:
-                    catalog._data_sets[name] = MlflowMetricsDataset(
+                    catalog._datasets[name] = MlflowMetricsDataset(
                         run_id=dataset._run_id, prefix=name
                     )
                 else:
-                    catalog._data_sets[name] = MlflowMetricsDataset(prefix=name)
+                    catalog._datasets[name] = MlflowMetricsDataset(prefix=name)
 
             if isinstance(dataset, MlflowMetricDataset) and dataset.key is None:
                 if dataset._run_id is not None:
-                    catalog._data_sets[name] = MlflowMetricDataset(
+                    catalog._datasets[name] = MlflowMetricDataset(
                         run_id=dataset._run_id,
                         key=name,
                         load_args=dataset._load_args,
                         save_args=dataset._save_args,
                     )
                 else:
-                    catalog._data_sets[name] = MlflowMetricDataset(
+                    catalog._datasets[name] = MlflowMetricDataset(
                         key=name,
                         load_args=dataset._load_args,
                         save_args=dataset._save_args,
@@ -166,14 +166,14 @@ class MlflowHook:
 
             if isinstance(dataset, MlflowMetricHistoryDataset) and dataset.key is None:
                 if dataset._run_id is not None:
-                    catalog._data_sets[name] = MlflowMetricHistoryDataset(
+                    catalog._datasets[name] = MlflowMetricHistoryDataset(
                         run_id=dataset._run_id,
                         key=name,
                         load_args=dataset._load_args,
                         save_args=dataset._save_args,
                     )
                 else:
-                    catalog._data_sets[name] = MlflowMetricHistoryDataset(
+                    catalog._datasets[name] = MlflowMetricHistoryDataset(
                         key=name,
                         load_args=dataset._load_args,
                         save_args=dataset._save_args,

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -27,7 +27,7 @@ from kedro_mlflow.io.catalog.switch_catalog_logging import switch_catalog_loggin
 from kedro_mlflow.io.metrics import (
     MlflowMetricDataset,
     MlflowMetricHistoryDataset,
-    MlflowMetricsDataset,
+    MlflowMetricsHistoryDataset,
 )
 from kedro_mlflow.mlflow import KedroPipelineModel
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
@@ -141,13 +141,16 @@ class MlflowHook:
         # we use this hooks to modif "MlflowmetricsDataset" to ensure consistency
         # of the metric name with the catalog name
         for name, dataset in catalog._datasets.items():
-            if isinstance(dataset, MlflowMetricsDataset) and dataset._prefix is None:
+            if (
+                isinstance(dataset, MlflowMetricsHistoryDataset)
+                and dataset._prefix is None
+            ):
                 if dataset._run_id is not None:
-                    catalog._datasets[name] = MlflowMetricsDataset(
+                    catalog._datasets[name] = MlflowMetricsHistoryDataset(
                         run_id=dataset._run_id, prefix=name
                     )
                 else:
-                    catalog._datasets[name] = MlflowMetricsDataset(prefix=name)
+                    catalog._datasets[name] = MlflowMetricsHistoryDataset(prefix=name)
 
             if isinstance(dataset, MlflowMetricDataset) and dataset.key is None:
                 if dataset._run_id is not None:

--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -15,20 +15,20 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
 
     def __new__(
         cls,
-        data_set: Union[str, Dict],
+        dataset: Union[str, Dict],
         run_id: str = None,
         artifact_path: str = None,
         credentials: Dict[str, Any] = None,
     ):
-        data_set, data_set_args = parse_dataset_definition(config=data_set)
+        dataset, dataset_args = parse_dataset_definition(config=dataset)
 
         # fake inheritance : this mlflow class should be a mother class which wraps
         # all dataset (i.e. it should replace AbstractVersionedDataset)
         # instead and since we can't modify the core package,
-        # we create a subclass which inherits dynamically from the data_set class
-        class MlflowArtifactDatasetChildren(data_set):
+        # we create a subclass which inherits dynamically from the dataset class
+        class MlflowArtifactDatasetChildren(dataset):
             def __init__(self, run_id, artifact_path):
-                super().__init__(**data_set_args)
+                super().__init__(**dataset_args)
                 self.run_id = run_id
                 self.artifact_path = artifact_path
                 self._logging_activated = True
@@ -134,7 +134,7 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
                 return super()._load()
 
         # rename the class
-        parent_name = data_set.__name__
+        parent_name = dataset.__name__
         MlflowArtifactDatasetChildren.__name__ = f"Mlflow{parent_name}"
         MlflowArtifactDatasetChildren.__qualname__ = (
             f"{parent_name}.Mlflow{parent_name}"

--- a/kedro_mlflow/io/catalog/switch_catalog_logging.py
+++ b/kedro_mlflow/io/catalog/switch_catalog_logging.py
@@ -1,4 +1,4 @@
 def switch_catalog_logging(catalog, logging_flag=True):
-    for name, data_set in catalog._data_sets.items():
-        if type(data_set).__name__.startswith("Mlflow"):
-            catalog._data_sets[name]._logging_activated = logging_flag
+    for name, dataset in catalog._datasets.items():
+        if type(dataset).__name__.startswith("Mlflow"):
+            catalog._datasets[name]._logging_activated = logging_flag

--- a/kedro_mlflow/io/metrics/__init__.py
+++ b/kedro_mlflow/io/metrics/__init__.py
@@ -1,3 +1,3 @@
 from .mlflow_metric_dataset import MlflowMetricDataset
 from .mlflow_metric_history_dataset import MlflowMetricHistoryDataset
-from .mlflow_metrics_dataset import MlflowMetricsDataset
+from .mlflow_metrics_dataset import MlflowMetricsHistoryDataset

--- a/kedro_mlflow/io/metrics/mlflow_abstract_metric_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_abstract_metric_dataset.py
@@ -13,7 +13,7 @@ class MlflowAbstractMetricDataset(AbstractDataset):
         load_args: Dict[str, Any] = None,
         save_args: Dict[str, Any] = None,
     ):
-        """Initialise MlflowMetricsDataset.
+        """Initialise MlflowMetricsHistoryDataset.
 
         Args:
             run_id (str): The ID of the mlflow run where the metric should be logged

--- a/kedro_mlflow/io/metrics/mlflow_metrics_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_metrics_dataset.py
@@ -11,7 +11,7 @@ MetricTuple = Tuple[str, float, int]
 MetricsDict = Dict[str, MetricItem]
 
 
-class MlflowMetricsDataset(AbstractDataset):
+class MlflowMetricsHistoryDataset(AbstractDataset):
     """This class represent MLflow metrics dataset."""
 
     def __init__(
@@ -19,7 +19,7 @@ class MlflowMetricsDataset(AbstractDataset):
         run_id: str = None,
         prefix: Optional[str] = None,
     ):
-        """Initialise MlflowMetricsDataset.
+        """Initialise MlflowMetricsHistoryDataset.
 
         Args:
             prefix (Optional[str]): Prefix for metrics logged in MLflow.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def kedro_project(tmp_path):
         output_dir=config["output_dir"],
         no_input=True,
         extra_context=config,
+        accept_hooks=False,
     )
 
     shutil.rmtree(

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -268,6 +268,7 @@ def test_ui_open_http_uri(monkeypatch, mocker, tmp_path):
         output_dir=config["output_dir"],
         no_input=True,
         extra_context=config,
+        accept_hooks=False,
     )
 
     project_path = tmp_path / config["repo_name"]

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -264,7 +264,7 @@ def test_modelify_logs_in_mlflow(monkeypatch, example_repo, artifacts_list):
 
     for artifact in artifacts_list:
         assert (
-            f"The data_set '{artifact}' is added to the Pipeline catalog"
+            f"The dataset '{artifact}' is added to the Pipeline catalog"
             in stripped_output
         )
     assert "Model successfully logged" in stripped_output

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -40,6 +40,7 @@ def kp_for_modelify(tmp_path):
         output_dir=config["output_dir"],
         no_input=True,
         extra_context=config,
+        accept_hooks=False,
     )
 
     shutil.rmtree(
@@ -143,6 +144,7 @@ def kp_for_modelify_with_parameters(tmp_path):
         output_dir=config["output_dir"],
         no_input=True,
         extra_context=config,
+        accept_hooks=False,
     )
 
     shutil.rmtree(

--- a/tests/framework/hooks/test_hook_deactivate_tracking.py
+++ b/tests/framework/hooks/test_hook_deactivate_tracking.py
@@ -63,7 +63,7 @@ def catalog_config(kedro_project_path):
             },
         },
         "metrics_data": {
-            "type": "kedro_mlflow.io.metrics.MlflowMetricsDataset",
+            "type": "kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset",
         },
         "metric_data": {
             "type": "kedro_mlflow.io.metrics.MlflowMetricDataset",

--- a/tests/framework/hooks/test_hook_deactivate_tracking.py
+++ b/tests/framework/hooks/test_hook_deactivate_tracking.py
@@ -79,7 +79,7 @@ def catalog_config(kedro_project_path):
     return {
         "artifact_data": {
             "type": "kedro_mlflow.io.artifacts.MlflowArtifactDataset",
-            "data_set": {
+            "dataset": {
                 "type": "pickle.PickleDataset",
                 "filepath": fake_data_filepath,
             },

--- a/tests/framework/hooks/test_hook_log_metrics.py
+++ b/tests/framework/hooks/test_hook_log_metrics.py
@@ -12,7 +12,7 @@ from kedro_mlflow.framework.hooks.mlflow_hook import MlflowHook
 from kedro_mlflow.io.metrics import (
     MlflowMetricDataset,
     MlflowMetricHistoryDataset,
-    MlflowMetricsDataset,
+    MlflowMetricsHistoryDataset,
 )
 
 
@@ -105,8 +105,8 @@ def dummy_catalog(tmp_path):
             "params:unused_param": MemoryDataset("blah"),
             "data": MemoryDataset(),
             "model": PickleDataset((tmp_path / "model.csv").as_posix()),
-            "my_metrics": MlflowMetricsDataset(),
-            "another_metrics": MlflowMetricsDataset(prefix="foo"),
+            "my_metrics": MlflowMetricsHistoryDataset(),
+            "another_metrics": MlflowMetricsHistoryDataset(prefix="foo"),
             "my_metric": MlflowMetricDataset(),
             "another_metric": MlflowMetricDataset(key="foo"),
             "my_metric_history": MlflowMetricHistoryDataset(),
@@ -181,8 +181,8 @@ def test_mlflow_hook_metrics_dataset_with_run_id(
                 "model": PickleDataset(
                     (kedro_project_with_mlflow_conf / "data" / "model.csv").as_posix()
                 ),
-                "my_metrics": MlflowMetricsDataset(run_id=existing_run_id),
-                "another_metrics": MlflowMetricsDataset(
+                "my_metrics": MlflowMetricsHistoryDataset(run_id=existing_run_id),
+                "another_metrics": MlflowMetricsHistoryDataset(
                     run_id=existing_run_id, prefix="foo"
                 ),
                 "my_metric": MlflowMetricDataset(run_id=existing_run_id),

--- a/tests/framework/hooks/test_hook_log_metrics.py
+++ b/tests/framework/hooks/test_hook_log_metrics.py
@@ -157,10 +157,10 @@ def test_mlflow_hook_automatically_prefix_metrics_dataset(
         )
         # Check if metrics datasets have prefix with its names.
         # for metric
-        assert dummy_catalog._data_sets["my_metrics"]._prefix == "my_metrics"
-        assert dummy_catalog._data_sets["another_metrics"]._prefix == "foo"
-        assert dummy_catalog._data_sets["my_metric"].key == "my_metric"
-        assert dummy_catalog._data_sets["another_metric"].key == "foo"
+        assert dummy_catalog._datasets["my_metrics"]._prefix == "my_metrics"
+        assert dummy_catalog._datasets["another_metrics"]._prefix == "foo"
+        assert dummy_catalog._datasets["my_metric"].key == "my_metric"
+        assert dummy_catalog._datasets["another_metric"].key == "foo"
 
 
 def test_mlflow_hook_metrics_dataset_with_run_id(

--- a/tests/framework/hooks/test_hook_log_parameters.py
+++ b/tests/framework/hooks/test_hook_log_parameters.py
@@ -134,7 +134,7 @@ def test_node_hook_logging(
     )
 
     node_inputs = {
-        v: dummy_catalog._data_sets.get(v) for k, v in dummy_node._inputs.items()
+        v: dummy_catalog._datasets.get(v) for k, v in dummy_node._inputs.items()
     }
 
     mlflow_tracking_uri = (kedro_project / "mlruns").as_uri()

--- a/tests/framework/hooks/test_hook_pipeline_ml.py
+++ b/tests/framework/hooks/test_hook_pipeline_ml.py
@@ -324,7 +324,7 @@ def test_mlflow_hook_save_pipeline_ml_with_copy_mode(
 
         actual_copy_mode = {
             name: ds._copy_mode
-            for name, ds in loaded_model._model_impl.python_model.loaded_catalog._data_sets.items()
+            for name, ds in loaded_model._model_impl.python_model.loaded_catalog._datasets.items()
         }
 
         assert actual_copy_mode == expected
@@ -380,7 +380,7 @@ def test_mlflow_hook_save_pipeline_ml_with_default_copy_mode_assign(
         assert all(
             [
                 ds._copy_mode == "assign"
-                for ds in loaded_model._model_impl.python_model.loaded_catalog._data_sets.values()
+                for ds in loaded_model._model_impl.python_model.loaded_catalog._datasets.values()
             ]
         )
 

--- a/tests/io/artifacts/test_mlflow_artifact_dataset.py
+++ b/tests/io/artifacts/test_mlflow_artifact_dataset.py
@@ -54,7 +54,7 @@ def test_mlflow_csv_pkl_dataset_save_reload(
 
     mlflow_dataset = MlflowArtifactDataset(
         artifact_path=artifact_path,
-        data_set=dict(type=dataset, filepath=filepath.as_posix()),
+        dataset=dict(type=dataset, filepath=filepath.as_posix()),
     )
 
     with mlflow.start_run():
@@ -99,7 +99,7 @@ def test_artifact_dataset_save_with_run_id(
 
     # then same scenario but the run_id where data is saved is specified
     mlflow_csv_dataset = MlflowArtifactDataset(
-        data_set=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
+        dataset=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
         run_id=run_id,
     )
     mlflow_csv_dataset.save(df1)
@@ -135,7 +135,7 @@ def test_is_versioned_dataset_logged_correctly_in_mlflow(tmp_path, tracking_uri,
         run_id = mlflow.active_run().info.run_id
 
         mlflow_csv_dataset = MlflowArtifactDataset(
-            data_set=dict(
+            dataset=dict(
                 type=CSVDataset,
                 filepath=(tmp_path / "df1.csv").as_posix(),
                 versioned=True,
@@ -173,7 +173,7 @@ def test_is_versioned_dataset_logged_correctly_in_mlflow(tmp_path, tracking_uri,
 
 def test_artifact_dataset_logging_deactivation(tmp_path, tracking_uri):
     mlflow_pkl_dataset = MlflowArtifactDataset(
-        data_set=dict(type=PickleDataset, filepath=(tmp_path / "df1.csv").as_posix())
+        dataset=dict(type=PickleDataset, filepath=(tmp_path / "df1.csv").as_posix())
     )
 
     mlflow.set_tracking_uri(tracking_uri.as_uri())
@@ -200,7 +200,7 @@ def test_artifact_dataset_logging_deactivation(tmp_path, tracking_uri):
 
 def test_mlflow_artifact_logging_deactivation_is_bool(tmp_path):
     mlflow_csv_dataset = MlflowArtifactDataset(
-        data_set=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix())
+        dataset=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix())
     )
 
     with pytest.raises(ValueError, match="_logging_activated must be a boolean"):
@@ -212,7 +212,7 @@ def test_artifact_dataset_load_with_run_id(tmp_path, tracking_uri, df1, df2):
 
     # define the logger
     mlflow_csv_dataset = MlflowArtifactDataset(
-        data_set=dict(type=CSVDataset, filepath=(tmp_path / "df.csv").as_posix())
+        dataset=dict(type=CSVDataset, filepath=(tmp_path / "df.csv").as_posix())
     )
 
     # create a first run, save a first dataset
@@ -240,7 +240,7 @@ def test_artifact_dataset_load_with_run_id_and_artifact_path(
 
     # save first and retrieve run id
     mlflow_csv_dataset1 = MlflowArtifactDataset(
-        data_set=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
+        dataset=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
         artifact_path=artifact_path,
     )
     with mlflow.start_run():
@@ -251,7 +251,7 @@ def test_artifact_dataset_load_with_run_id_and_artifact_path(
         ).unlink()  # we need to delete the data, else it is automatically reused instead of downloading
     # same as before, but a closed run_id is specified
     mlflow_csv_dataset2 = MlflowArtifactDataset(
-        data_set=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
+        dataset=dict(type=CSVDataset, filepath=(tmp_path / "df1.csv").as_posix()),
         artifact_path=artifact_path,
         run_id=first_run_id,
     )
@@ -271,7 +271,7 @@ def test_partitioned_dataset_save_and_reload(
 
     mlflow_dataset = MlflowArtifactDataset(
         artifact_path=artifact_path,
-        data_set=dict(
+        dataset=dict(
             type=PartitionedDataset,
             path=(tmp_path / "df_dir").as_posix(),
             dataset="pandas.CSVDataset",

--- a/tests/io/metrics/test_mlflow_metrics_dataset.py
+++ b/tests/io/metrics/test_mlflow_metrics_dataset.py
@@ -6,7 +6,7 @@ from kedro.io import DatasetError
 from mlflow.tracking import MlflowClient
 from pytest_lazyfixture import lazy_fixture
 
-from kedro_mlflow.io.metrics import MlflowMetricsDataset
+from kedro_mlflow.io.metrics import MlflowMetricsHistoryDataset
 
 
 def assert_are_metrics_logged(
@@ -81,12 +81,12 @@ def metrics3():
     ],
 )
 def test_mlflow_metrics_dataset_saved_and_logged(tmp_path, tracking_uri, data, prefix):
-    """Check if MlflowMetricsDataset can be saved in catalog when filepath is given,
+    """Check if MlflowMetricsHistoryDataset can be saved in catalog when filepath is given,
     and if logged in mlflow.
     """
     mlflow.set_tracking_uri(tracking_uri.as_uri())
     mlflow_client = MlflowClient(tracking_uri=tracking_uri.as_uri())
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix=prefix)
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix=prefix)
 
     with mlflow.start_run():
         run_id = mlflow.active_run().info.run_id
@@ -96,7 +96,7 @@ def test_mlflow_metrics_dataset_saved_and_logged(tmp_path, tracking_uri, data, p
         assert_are_metrics_logged(data, mlflow_client, run_id, prefix)
 
     # Check if metrics are stored in catalog.
-    catalog_metrics = MlflowMetricsDataset(
+    catalog_metrics = MlflowMetricsHistoryDataset(
         prefix=prefix,
         # Run id needs to be provided as there is no active run.
         run_id=run_id,
@@ -109,14 +109,14 @@ def test_mlflow_metrics_dataset_saved_and_logged(tmp_path, tracking_uri, data, p
 
 
 def test_mlflow_metrics_dataset_saved_without_run_id(tmp_path, tracking_uri, metrics3):
-    """Check if MlflowMetricsDataset can be saved in catalog when filepath is given,
+    """Check if MlflowMetricsHistoryDataset can be saved in catalog when filepath is given,
     and if logged in mlflow.
     """
     prefix = "test_metric"
 
     mlflow.set_tracking_uri(tracking_uri.as_uri())
     mlflow_client = MlflowClient(tracking_uri=tracking_uri.as_uri())
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix=prefix)
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix=prefix)
 
     # a mlflow run_id is automatically created
     mlflow_metrics_dataset.save(metrics3)
@@ -126,13 +126,13 @@ def test_mlflow_metrics_dataset_saved_without_run_id(tmp_path, tracking_uri, met
 
 
 def test_mlflow_metrics_dataset_exists(tmp_path, tracking_uri, metrics3):
-    """Check if MlflowMetricsDataset is well identified as
+    """Check if MlflowMetricsHistoryDataset is well identified as
     existing if it has already been saved.
     """
     prefix = "test_metric"
 
     mlflow.set_tracking_uri(tracking_uri.as_uri())
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix=prefix)
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix=prefix)
 
     # a mlflow run_id is automatically created
     mlflow_metrics_dataset.save(metrics3)
@@ -140,7 +140,7 @@ def test_mlflow_metrics_dataset_exists(tmp_path, tracking_uri, metrics3):
 
 
 def test_mlflow_metrics_dataset_does_not_exist(tmp_path, tracking_uri, metrics3):
-    """Check if MlflowMetricsDataset is well identified as
+    """Check if MlflowMetricsHistoryDataset is well identified as
     not existingif it has never been saved.
     """
 
@@ -148,7 +148,9 @@ def test_mlflow_metrics_dataset_does_not_exist(tmp_path, tracking_uri, metrics3)
     mlflow.start_run()  # starts a run toenable mlflow_metrics_dataset to know where to seacrh
     run_id = mlflow.active_run().info.run_id
     mlflow.end_run()
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix="test_metric", run_id=run_id)
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(
+        prefix="test_metric", run_id=run_id
+    )
     # a mlflow run_id is automatically created
     assert not mlflow_metrics_dataset.exists()
 
@@ -156,12 +158,12 @@ def test_mlflow_metrics_dataset_does_not_exist(tmp_path, tracking_uri, metrics3)
 def test_mlflow_metrics_dataset_fails_with_invalid_metric(
     tmp_path, tracking_uri, metrics3
 ):
-    """Check if MlflowMetricsDataset is well identified as
+    """Check if MlflowMetricsHistoryDataset is well identified as
     not existingif it has never been saved.
     """
 
     mlflow.set_tracking_uri(tracking_uri.as_uri())
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix="test_metric")
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix="test_metric")
 
     with pytest.raises(
         DatasetError, match="Unexpected metric value. Should be of type"
@@ -172,7 +174,7 @@ def test_mlflow_metrics_dataset_fails_with_invalid_metric(
 
 
 def test_mlflow_metrics_logging_deactivation(tracking_uri, metrics):
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix="hello")
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix="hello")
 
     mlflow.set_tracking_uri(tracking_uri.as_uri())
     mlflow_client = MlflowClient(tracking_uri=tracking_uri.as_uri())
@@ -197,7 +199,7 @@ def test_mlflow_metrics_logging_deactivation(tracking_uri, metrics):
 
 
 def test_mlflow_metrics_logging_deactivation_is_bool():
-    mlflow_metrics_dataset = MlflowMetricsDataset(prefix="hello")
+    mlflow_metrics_dataset = MlflowMetricsHistoryDataset(prefix="hello")
 
     with pytest.raises(ValueError, match="_logging_activated must be a boolean"):
         mlflow_metrics_dataset._logging_activated = "hello"

--- a/tests/io/models/test_mlflow_model_local_filesystem_dataset.py
+++ b/tests/io/models/test_mlflow_model_local_filesystem_dataset.py
@@ -87,7 +87,7 @@ def dummy_catalog(tmp_path):
             ),
         }
     )
-    dummy_catalog._data_sets["model"].save(2)  # emulate model fitting
+    dummy_catalog._datasets["model"].save(2)  # emulate model fitting
 
     return dummy_catalog
 

--- a/tests/io/models/test_mlflow_model_tracking_dataset.py
+++ b/tests/io/models/test_mlflow_model_tracking_dataset.py
@@ -107,7 +107,7 @@ def dummy_catalog(tmp_path):
             ),
         }
     )
-    dummy_catalog._data_sets["model"].save(2)  # emulate model fitting
+    dummy_catalog._datasets["model"].save(2)  # emulate model fitting
 
     return dummy_catalog
 

--- a/tests/mlflow/test_kedro_pipeline_model.py
+++ b/tests/mlflow/test_kedro_pipeline_model.py
@@ -263,7 +263,7 @@ def dummy_catalog(tmp_path):
 def test_model_packaging_with_copy_mode(
     tmp_path, tmp_folder, pipeline_inference_dummy, dummy_catalog, copy_mode, expected
 ):
-    dummy_catalog._data_sets["model"].save(2)  # emulate model fitting
+    dummy_catalog._datasets["model"].save(2)  # emulate model fitting
 
     kedro_model = KedroPipelineModel(
         pipeline=pipeline_inference_dummy,
@@ -293,7 +293,7 @@ def test_model_packaging_with_copy_mode(
     # second assertion: copy_mode works
     actual_copy_mode = {
         name: ds._copy_mode
-        for name, ds in loaded_model._model_impl.python_model.loaded_catalog._data_sets.items()
+        for name, ds in loaded_model._model_impl.python_model.loaded_catalog._datasets.items()
     }
 
     assert actual_copy_mode == expected
@@ -331,15 +331,15 @@ def test_model_packaging_too_many_artifacts(tmp_path, pipeline_inference_dummy):
         }
     )
 
-    catalog._data_sets["raw_data"].save(1)  # emulate input on disk
-    catalog._data_sets["model"].save(2)  # emulate model fitting
+    catalog._datasets["raw_data"].save(1)  # emulate input on disk
+    catalog._datasets["model"].save(2)  # emulate model fitting
 
     # the input is persited
     artifacts = {
         name: Path(dataset._filepath.as_posix())
         .resolve()
         .as_uri()  # weird bug when directly converting PurePosixPath to windows: it is considered as relative
-        for name, dataset in catalog._data_sets.items()
+        for name, dataset in catalog._datasets.items()
         if not isinstance(dataset, MemoryDataset)
     }
 
@@ -572,7 +572,7 @@ def test_kedro_pipeline_model_save_and_load(
         pipeline=pipeline, catalog=catalog, input_name=input_name
     )
     # emulate artifacts persistence
-    for ds in catalog._data_sets.values():
+    for ds in catalog._datasets.values():
         if hasattr(ds, "_filepath") is not None:
             ds.save(1)
 


### PR DESCRIPTION
## Description
Prepare kedro 0.19 release

## Development notes

- fix failing tests due to cookiecutter hooks
- :boom: rename all ``data_set`` entries int eh code by ``dataset``. This changes the signature of ``MLflowArtifactDataSet``.
- Refactor tests to remove logging monkeypatching. this makes tests simpler. 

Notice that tests do not pass because we are on the latest 0.18.x version, but they dont pass either on the develop branch because of following issues: https://github.com/kedro-org/kedro/issues/3214

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes


## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
