### PR TITLE
Prevent tests from creating mlruns folder in several places (#475)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ dmypy.json
 # mlflow
 mlruns/
 
+# ruff
+.ruff_cache
+
 debug/
 *.xlsx
 *.pptx


### PR DESCRIPTION
## Description
Close #475

## Development notes
Lots of experimentation: 
- I can't increase tests speeds, because the only thing (by a vast margin) that is really slow is the ``log_model`` function in mlflow. 
- I tried to avoid runnnigs tests creatings a bunch of mlruns folder, especially at the root of the projects. The solution was to change the fixture which cleanup after each tets, because a "gloabl" variable created in mlflow was the root cause of everything. See comment here : https://github.com/Galileo-Galilei/kedro-mlflow/pull/478/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R37-R44
I also move some fixture (``tracking_uri`` & ``mlflow_client`` to ``conftest.py`` to remove duplicated code. 

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
