### PR TITLE
:bug: Materialize dataset factories before instantiating KedroPipelineModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [0.12.0] - 2023-12-19
-
 ### Fixed
 
--   :bug: Add support for dataset factories in KedroPipelineML ([#516, rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/519))
+-   :bug: Add support for dataset factories in KedroPipelineML ([#516, sebastiandro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/519))
+
+## [0.12.0] - 2023-12-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   :bug: Add support for dataset factories in KedroPipelineML ([#516, sebastiandro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/519))
+-   :bug: Add support for dataset factories in ``KedroPipelineModel`` ([#516, sebastiandro](https://github.com/Galileo-Galilei/kedro-mlflow/pull/516))
 
 ## [0.12.0] - 2023-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [0.12.0] - 2023-12-19
 
+### Fixed
+
+-   :bug: Add support for dataset factories in KedroPipelineML ([#516, rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/519))
+
 ### Added
 
 -   :sparkles: Add support for python 3.11 ([#450, rxm7706](https://github.com/Galileo-Galilei/kedro-mlflow/pull/450))

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -352,6 +352,10 @@ class MlflowHook:
         """
         if self._is_mlflow_enabled:
             if isinstance(pipeline, PipelineML):
+                # Materialize dataset factories
+                for dataset in pipeline.datasets():
+                    catalog.exists(dataset)
+
                 with TemporaryDirectory() as tmp_dir:
                     # This will be removed at the end of the context manager,
                     # but we need to log in mlflow before moving the folder

--- a/tests/framework/hooks/test_hook_pipeline_ml.py
+++ b/tests/framework/hooks/test_hook_pipeline_ml.py
@@ -631,17 +631,12 @@ def test_mlflow_hook_save_pipeline_ml_with_artifact_path(
         assert trained_model is not None
 
 
-@pytest.mark.parametrize(
-    "namespace",
-    (["a", "b"]),
-)
 def test_mlflow_hook_save_pipeline_ml_with_dataset_factory(
     kedro_project_with_mlflow_conf,
     env_from_dict,
     dummy_pipeline_dataset_factory,
     dummy_catalog_dataset_factory,
     dummy_run_params,
-    namespace,
 ):
     """
     Test for PipelineML factory where the input catalog has data factories.
@@ -657,6 +652,7 @@ def test_mlflow_hook_save_pipeline_ml_with_dataset_factory(
             "conda_env": env_from_dict,
         }
 
+        namespace = "a"
         log_model_kwargs["artifact_path"] = "artifacts"
         dummy_pipeline_with_namespace = pipeline(
             pipe=dummy_pipeline_dataset_factory, namespace=namespace


### PR DESCRIPTION
## Description
This PR fixes the problem with PipelineML not recognizing catalogue entities with dataset factory patterns.

## Development notes
The `after_pipeline_run` was updated to run `catalog.exists` for all pipeline datasets, as suggested by @Galileo-Galilei 

A unit test was added for the case when a DataCatalog has data factory patterns.

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
