### PR TITLE
Make project level cli work inside subdirectory (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@
 
 ### Changed
 
-- :sparkles: Project level CLI commands ``kedro mlflow init``, ``kedro mlflow ui`` and ``kedro mlflow modelify`` now works even inside a subdirectory and not at the root of the kedro project to be [consistent with ``kedro>0.19.4``](https://github.com/kedro-org/kedro/blob/main/RELEASE.md#major-features-and-improvements-1) ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
+- :sparkles: Project level CLI commands ``kedro mlflow init``, ``kedro mlflow ui`` and ``kedro mlflow modelify`` now work even inside a subdirectory and not at the root of the kedro project to be [consistent with ``kedro>0.19.4``](https://github.com/kedro-org/kedro/blob/main/RELEASE.md#major-features-and-improvements-1) ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
 
 ### Fixed
 
-- :bug: Proxy import of private kedro function ``_is_project`` and ``_find_kedro_project`` to be resilient to changes ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
+- :bug: Proxy import of private kedro functions ``_is_project`` and ``_find_kedro_project`` to be resilient to changes ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
 
 ## [0.12.1] - 2024-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 -   :construction_worker: :package: Add build distribution (instead of source only distribution) to PyPI release to make install easier and faster ([#515](https://github.com/Galileo-Galilei/kedro-mlflow/issues/515))
 -   :memo: Document the ability to update configuration at runtime ([#395](https://github.com/Galileo-Galilei/kedro-mlflow/issues/395))
 
+### Changed
+
+- :sparkles: Project level CLI commands ``kedro mlflow init``, ``kedro mlflow ui`` and ``kedro mlflow modelify`` now works even inside a subdirectory and not at the root of the kedro project to be [consistent with ``kedro>0.19.4``](https://github.com/kedro-org/kedro/blob/main/RELEASE.md#major-features-and-improvements-1) ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
+
+### Fixed
+
+- :bug: Proxy import of private kedro function ``_is_project`` and ``_find_kedro_project`` to be resilient to changes ([#531](https://github.com/Galileo-Galilei/kedro-mlflow/issues/531))
+
 ## [0.12.1] - 2024-02-09
 
 ### Added

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -89,7 +89,6 @@ def init(env: str, force: bool, silent: bool):
     # get constants
     mlflow_yml = "mlflow.yml"
     project_path = _find_kedro_project(Path.cwd()) or Path.cwd()
-    project_path = Path.cwd()
     project_metadata = bootstrap_project(project_path)
     mlflow_yml_path = project_path / settings.CONF_SOURCE / env / mlflow_yml
 

--- a/kedro_mlflow/utils.py
+++ b/kedro_mlflow/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import Any, List, Union
 
 
 def _parse_requirements(path: Union[str, Path], encoding="utf-8") -> List:
@@ -8,3 +8,23 @@ def _parse_requirements(path: Union[str, Path], encoding="utf-8") -> List:
             x.strip() for x in file_handler if x.strip() and not x.startswith("-r")
         ]
     return requirements
+
+
+def _is_project(project_path: Union[str, Path]) -> bool:
+    try:
+        # untested in the CI, for retrocompatiblity with kedro >=0.19.0,<0.19.3
+        from kedro.framework.startup import _is_project as _ip
+    except ImportError:
+        from kedro.utils import _is_project as _ip
+
+    return _ip(project_path)
+
+
+def _find_kedro_project(current_dir: Path) -> Any:
+    try:
+        # untested in the CI, for retrocompatiblity with kedro >=0.19.0,<0.19.3
+        from kedro.framework.startup import _find_kedro_project as _fkp
+    except ImportError:
+        from kedro.utils import _find_kedro_project as _fkp
+
+    return _fkp(current_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kedro>=0.19.0, <0.20.0
+kedro>=0.19.4, <0.20.0
 kedro_datasets
 mlflow>=1.0.0, <3.0.0
 pydantic>=1.0.0, <3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kedro>=0.19.4, <0.20.0
+kedro>=0.19.0, <0.20.0
 kedro_datasets
 mlflow>=1.0.0, <3.0.0
 pydantic>=1.0.0, <3.0.0

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -64,16 +64,15 @@ def test_cli_global_discovered(monkeypatch, tmp_path):
 # because discovery mechanisme is linked to setup.py
 
 
-## This command is temporarlily deactivated beacuse of a bug in kedro==0.17.3, see: https://github.com/Galileo-Galilei/kedro-mlflow/issues/193
-# def test_mlflow_commands_outside_kedro_project(monkeypatch, tmp_path):
-#     monkeypatch.chdir(tmp_path)
-#     cli_runner = CliRunner()
-#     result = cli_runner.invoke(cli_mlflow)
-#     assert {"new"} == set(extract_cmd_from_help(result.output))
+@pytest.mark.parametrize("inside_subdirectory", (True, False))
+def test_mlflow_commands_inside_kedro_project(
+    monkeypatch, kedro_project, inside_subdirectory
+):
+    if inside_subdirectory is True:
+        monkeypatch.chdir(kedro_project / "src")
+    else:
+        monkeypatch.chdir(kedro_project)
 
-
-def test_mlflow_commands_inside_kedro_project(monkeypatch, kedro_project):
-    monkeypatch.chdir(kedro_project)
     # launch the command to initialize the project
     cli_runner = CliRunner()
     result = cli_runner.invoke(cli_mlflow)
@@ -81,9 +80,13 @@ def test_mlflow_commands_inside_kedro_project(monkeypatch, kedro_project):
     assert "You have not updated your template yet" not in result.output
 
 
-def test_cli_init(monkeypatch, kedro_project):
+@pytest.mark.parametrize("inside_subdirectory", (True, False))
+def test_cli_init(monkeypatch, kedro_project, inside_subdirectory):
     # "kedro_project" is a pytest.fixture declared in conftest
-    monkeypatch.chdir(kedro_project)
+    if inside_subdirectory is True:
+        monkeypatch.chdir(kedro_project / "src")
+    else:
+        monkeypatch.chdir(kedro_project)
     cli_runner = CliRunner()
     result = cli_runner.invoke(cli_init)
 
@@ -177,6 +180,7 @@ def test_cli_init_with_env(monkeypatch, kedro_project, env):
 )
 def test_cli_init_with_wrong_env(monkeypatch, kedro_project, env):
     # "kedro_project" is a pytest.fixture declared in conftest
+
     monkeypatch.chdir(kedro_project)
     cli_runner = CliRunner()
     result = cli_runner.invoke(cli_init, f"--env {env}")
@@ -189,8 +193,15 @@ def test_cli_init_with_wrong_env(monkeypatch, kedro_project, env):
 # I tried mimicking mlflow_cli with mock but did not achieve desired result
 # other solution is to use pytest-xprocess
 # TODO: create an initlaized_kedro_project fixture with a global scope
-def test_ui_is_up(monkeypatch, mocker, kedro_project_with_mlflow_conf):
-    monkeypatch.chdir(kedro_project_with_mlflow_conf)
+@pytest.mark.parametrize("inside_subdirectory", (True, False))
+def test_cli_ui_is_up(
+    monkeypatch, mocker, kedro_project_with_mlflow_conf, inside_subdirectory
+):
+    if inside_subdirectory is True:
+        monkeypatch.chdir(kedro_project_with_mlflow_conf / "src")
+    else:
+        monkeypatch.chdir(kedro_project_with_mlflow_conf)
+
     cli_runner = CliRunner()
 
     # This does not test anything : the goal is to check whether it raises an error


### PR DESCRIPTION
## Description

- Fix a bug which prevents importng the CLi with kedro==0.19.4 because I relied on private ``_is_project``.
- On the way, make all project level CLI (``init``, ``ui``, and ``modelify``) work inside a subdirectory and not only at the root of kedro level

## Development notes

- Create my own ``_is_project`` and ``_find_kedro_project`` functions which manges the import of the private functions of kedro.
- Change all CLI to get the project path with ``_find_kedro_project`` instead of taking ``Path.cwd``. 

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
