### PR TITLE
:closed_lock_with_key: Use OIDC to authentify with PYPI and update dependencies versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,40 +5,42 @@ on: workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.11]
+    environment:
+      name: release
+    permissions:
+      contents: write  # IMPORTANT: this permission is mandatory to enable creating a release
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     env:
       PYTHON_PACKAGE: kedro_mlflow
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0  # necessary to enable merging, all the history is needed
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.11"
     - name: Build package dist from source # A better way will be : https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ but pep 517 is still marked as experimental
       run: |
         pip install wheel
         python setup.py sdist bdist_wheel
-    - name: Set dynamically package version as output variable # see https://github.com/actions/create-release/issues/39
-      # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+    - name: Set dynamically package version as output variable
+      # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
       id: set_package_version
       run: |
-        echo "::set-output name=PACKAGE_VERSION::$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')"
+        echo "PACKAGE_VERSION=$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')" >> "$GITHUB_OUTPUT"
     - name: Create temporary file with the body content for the release
       run: |
         grep -Poz "## \[${{steps.set_package_version.outputs.PACKAGE_VERSION}}] - \d{4}-\d{2}-\d{2}[\S\s]+?(?=## \[\d+\.\d+\.\d+\]|\[.+\]:)" CHANGELOG.md > release_body.md
-    - name: Create Release # https://github.com/actions/create-release
+    - name: Create Release
       id: create_release
-      uses: actions/create-release@v1.1.4
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         tag_name: ${{ steps.set_package_version.outputs.PACKAGE_VERSION }}
-        release_name: Release ${{ steps.set_package_version.outputs.PACKAGE_VERSION }}
+        name: Release ${{ steps.set_package_version.outputs.PACKAGE_VERSION }}
         body_path: ./release_body.md
         draft: false
         prerelease: false
@@ -50,16 +52,8 @@ jobs:
         release_id: ${{ steps.create_release.outputs.id }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # - name: Publish distribution to Test PyPI  # official action from python maintainers
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.TEST_PYPI_PASSWORD }}
-    #     repository_url: https://test.pypi.org/legacy/
-    #     verbose: true  # trace if the upload fails
-    - name: Publish distribution to PyPI  # official action from python maintainers
+
+    - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
         verbose: true  # trace if the upload fails


### PR DESCRIPTION
## Description

Use OIDC to connect to PyPI when releasing for more security, and update actions with more reputed ones or newer versions

## Development notes
Use publish.yml from kedro-pandera updated recently.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
