### PR TITLE
Handle inference parameters

### DIFF
--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -371,6 +371,7 @@ class MlflowHook:
                         pipeline=pipeline.inference,
                         catalog=catalog,
                         input_name=pipeline.input_name,
+                        params_input_name=pipeline.params_input_name,
                         **pipeline.kpm_kwargs,
                     )
                     artifacts = kedro_pipeline_model.extract_pipeline_artifacts(

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -131,11 +131,11 @@ class PipelineML(Pipeline):
         self._input_name = name
 
     @property
-    def params_input_name(self) -> str | None:
+    def params_input_name(self) -> Optional[str]:
         return self._params_input_name
 
     @params_input_name.setter
-    def params_input_name(self, name: str | None) -> None:
+    def params_input_name(self, name: Optional[str]) -> None:
         if name is not None:
             allowed_names = self.inference.inputs()
             pp_allowed_names = "\n    - ".join(allowed_names)

--- a/kedro_mlflow/pipeline/pipeline_ml_factory.py
+++ b/kedro_mlflow/pipeline/pipeline_ml_factory.py
@@ -1,14 +1,16 @@
 from kedro.pipeline import Pipeline
 
 from kedro_mlflow.pipeline.pipeline_ml import PipelineML
+from typing import Optional
 
 
 def pipeline_ml_factory(
     training: Pipeline,
     inference: Pipeline,
-    input_name: str = None,
+    input_name: str,
     kpm_kwargs=None,
     log_model_kwargs=None,
+    params_input_name: Optional[str] = None,
 ) -> PipelineML:
     """This function is a helper to create `PipelineML`
     object directly from two Kedro `Pipelines` (one of
@@ -23,9 +25,9 @@ def pipeline_ml_factory(
             stored in mlflow and use the output(s)
             of the training pipeline (namely, the model)
             to predict the outcome.
-        input_name (str, optional): The name of the dataset in
+        input_name (str): The name of the dataset in
             the catalog.yml which the model's user must provide
-            for prediction (i.e. the data). Defaults to None.
+            for prediction (i.e. the data).
         kpm_kwargs:
             extra arguments to be passed to `KedroPipelineModel`
             when the PipelineML object is automatically saved at the end of a run.
@@ -37,6 +39,7 @@ def pipeline_ml_factory(
             extra arguments to be passed to `mlflow.pyfunc.log_model`
             when the PipelineML object is automatically saved at the end of a run.
             See mlflow documentation to see all available options: https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model
+        params_input_name (str, optional): TODO
 
     Returns:
         PipelineML: A `PipelineML` which is automatically
@@ -51,5 +54,6 @@ def pipeline_ml_factory(
         input_name=input_name,
         kpm_kwargs=kpm_kwargs,
         log_model_kwargs=log_model_kwargs,
+        params_input_name=params_input_name,
     )
     return pipeline


### PR DESCRIPTION
## Description
Closes #445

This PR enables passing in inference params during prediction to the packaged model as an additional input to the inference pipeline.

## Development notes

This change is fully backwards compatible. One can choose to use inference params during prediction by supplying `params_input_name` in addition to the `input_name` during PipelineML creation. The inference pipeline then would need to have a secondary input called after `params_input_name`, where the [params dict passed in predict](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.PyFuncModel.predict) would be saved.

The motivation for this change was to quickly have a way to pass parameters at runtime that influences the model logic (e.g. choosing different endpoint to hit for data extraction). Thought it's worth sharing.

Although no changes to unit tests were made yet, the ones that exist already are passing, which should indicate that it's indeed backwards compatible. The proposed solution works in a real-life kedro project where the model is being packaged and served.

No time was spent to think about https://github.com/Galileo-Galilei/kedro-mlflow/issues/445#issuecomment-1783917523. User can pass anything he pleases that can be saved as a separate dict later to be used in the pipeline. It's impossible to overwrite other catalog entries or parameters.

Opening as a draft PR. I'm happy to collaborate on this more, but unsure if I'll have capacity to finish all the remaining tasks

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
