### PR TITLE
Allow only_nodes_with_namespace in PipelineML for kedro-viz compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
--   :bug: Allow ``only_nodes_with_namespace`` in ``PipelineML`` for ``kedro-viz>=9.2.0`` compatibility ([#569](https://github.com/Galileo-Galilei/kedro-mlflow/issues/569))
+-   :bug: Implement ``only_nodes_with_namespace`` and ``__sub__`` methods in ``PipelineML`` for ``kedro-viz>=9.2.0`` compatibility ([#569](https://github.com/Galileo-Galilei/kedro-mlflow/issues/569))
 
 
 ## [0.12.2] - 2024-04-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 -   :memo: :loud_sound:  Various improvements to documentation and logging ([#549](https://github.com/Galileo-Galilei/kedro-mlflow/issues/549), [#554](https://github.com/Galileo-Galilei/kedro-mlflow/issues/554), [#567](https://github.com/Galileo-Galilei/kedro-mlflow/issues/567))
 
+### Fixed
+
+-   :bug: Allow ``only_nodes_with_namespace`` in ``PipelineML`` for ``kedro-viz>=9.2.0`` compatibility ([#569](https://github.com/Galileo-Galilei/kedro-mlflow/issues/569))
+
+
 ## [0.12.2] - 2024-04-18
 
 ### Added

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -1,3 +1,4 @@
+from logging import Logger, getLogger
 from typing import Dict, Iterable, Optional, Union
 
 from kedro.pipeline import Pipeline
@@ -8,6 +9,14 @@ MSG_NOT_IMPLEMENTED = (
     "not make sense for 'PipelineML'. "
     "Manipulate directly the training pipeline and "
     "recreate the 'PipelineML' with 'pipeline_ml_factory' factory."
+)
+
+MSG_WARNING_KEDRO_VIZ = (
+    "BEWARE - This 'Pipeline' is no longer a 'PipelineML' object. "
+    "This method is only implemented for compatibility with kedro-viz "
+    "but should never be used directly.\nSee "
+    "https://github.com/Galileo-Galilei/kedro-mlflow/issues/569 "
+    " for more context. "
 )
 
 
@@ -85,6 +94,10 @@ class PipelineML(Pipeline):
         log_model_kwargs = log_model_kwargs or {}
         self.log_model_kwargs = {**self.LOG_MODEL_KWARGS_DEFAULT, **log_model_kwargs}
         self._check_consistency()
+
+    @property
+    def _logger(self) -> Logger:
+        return getLogger(__name__)
 
     @property
     def training(self) -> Pipeline:
@@ -165,7 +178,8 @@ class PipelineML(Pipeline):
     def only_nodes_with_namespace(
         self, node_namespace: str
     ) -> "Pipeline":  # pragma: no cover
-        raise NotImplementedError(MSG_NOT_IMPLEMENTED)
+        self._logger(MSG_WARNING_KEDRO_VIZ)
+        return self.training.only_nodes_with_namespace(node_namespace)
 
     def only_nodes_with_inputs(self, *inputs: str) -> "PipelineML":  # pragma: no cover
         raise NotImplementedError(MSG_NOT_IMPLEMENTED)
@@ -235,7 +249,8 @@ class PipelineML(Pipeline):
         raise NotImplementedError(MSG_NOT_IMPLEMENTED)
 
     def __sub__(self, other):  # pragma: no cover
-        raise NotImplementedError(MSG_NOT_IMPLEMENTED)
+        self._logger(MSG_WARNING_KEDRO_VIZ)
+        return self.training - other
 
     def __and__(self, other):  # pragma: no cover
         # kept for compatibility with KedroContext _filter_pipelinefunction

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -178,7 +178,7 @@ class PipelineML(Pipeline):
     def only_nodes_with_namespace(
         self, node_namespace: str
     ) -> "Pipeline":  # pragma: no cover
-        self._logger(MSG_WARNING_KEDRO_VIZ)
+        self._logger.warning(MSG_WARNING_KEDRO_VIZ)
         return self.training.only_nodes_with_namespace(node_namespace)
 
     def only_nodes_with_inputs(self, *inputs: str) -> "PipelineML":  # pragma: no cover
@@ -249,7 +249,7 @@ class PipelineML(Pipeline):
         raise NotImplementedError(MSG_NOT_IMPLEMENTED)
 
     def __sub__(self, other):  # pragma: no cover
-        self._logger(MSG_WARNING_KEDRO_VIZ)
+        self._logger.warning(MSG_WARNING_KEDRO_VIZ)
         return self.training - other
 
     def __and__(self, other):  # pragma: no cover


### PR DESCRIPTION
## Description
Close #569

## Development notes

- Add ``only_nodes_with_namespace`` and ``__sub__`` methods for ``PipelineML`` object
- I have tested manually but kedro-viz 9.2.0 does not fail with a simple PipelineML in spaceflights-pandas. I need 


## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
