### PR TITLE
:bug: Force return on load for old style datasets (#592)

### DIFF
--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -137,7 +137,7 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
                 if getattr(super().load, "__loadwrapped__", False):  # modern dataset
                     return super().load.__wrapped__(self)
                 else:  # legacy dataset
-                    super()._load()
+                    return super()._load()
 
         # rename the class
         parent_name = dataset_obj.__name__

--- a/tests/framework/cli/test_cli_modelify.py
+++ b/tests/framework/cli/test_cli_modelify.py
@@ -466,7 +466,7 @@ def test_modelify_with_infer_input_example(
         "artifact_path": "input_example.json",
         "pandas_orient": "split",
         "type": "dataframe",
-        "serving_input_path": "serving_input_payload.json",
+        "serving_input_path": "serving_input_example.json",
     }
 
 


### PR DESCRIPTION
## Description

Close #592

## Development notes

add a return statement on MLflowArtifactDataset._load for old style dataset

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
