### PR TITLE
:bug: :ambulance: Make MlflowArtifactDataset load and save compatible with modern datasets without private _load and _save (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+:bug: :ambulance: Fix ``MlflowArtifactDataset`` ``load`` and ``save`` methods to make them compatible with modern datasets without private ``_load`` and ``_save`` introduced in ``kedro-datasets>=5.0.0`` ([#598](https://github.com/Galileo-Galilei/kedro-mlflow/issues/598))
+
 ## [0.13.1] - 2024-09-24
 
 ### Added

--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -62,7 +62,7 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
                 # for logging on remote storage like Azure S3
                 local_path = local_path.as_posix()
 
-                if getattr(super().save, "__savewrapped__", False):  # modern dataset
+                if hasattr(super().save, "__wrapped__"):  # modern dataset
                     super().save.__wrapped__(self, data)
                 else:  # legacy dataset
                     super()._save(data)
@@ -134,7 +134,7 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
                     shutil.copy(src=temp_download_filepath, dst=local_path)
 
                 # finally, read locally
-                if getattr(super().load, "__loadwrapped__", False):  # modern dataset
+                if hasattr(super().load, "__wrapped__"):  # modern dataset
                     return super().load.__wrapped__(self)
                 else:  # legacy dataset
                     return super()._load()


### PR DESCRIPTION
## Description

Fix #598

## Development notes
What have you changed, and how has this been tested?

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
