### PR TITLE
:memo: :construction_worker: Fix documentation reference to quickstart

### DIFF
--- a/docs/source/02_installation/02_setup.md
+++ b/docs/source/02_installation/02_setup.md
@@ -6,7 +6,7 @@ This section assume that [you have installed `kedro-mlflow` in your virtual envi
 
 This plugin must be used in an existing kedro project. If you do not have a kedro project yet, you can create it with ``kedro new`` command. [See the kedro docs for a tutorial](https://kedro.readthedocs.io/en/latest/get_started/new_project.html).
 
-If you do not have a real-world project, you can use a kedro example and [follow the "Getting started" example](../03_getting_started/01_example_project.md) to make a demo of this plugin out of the box.
+If you do not have a real-world project, you can use a kedro example and [follow the "Quickstart in 1 mn" example](../03_quickstart/01_example_project.md) to make a demo of this plugin out of the box.
 
 ## Activate `kedro-mlflow` in your kedro project
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,4 +97,4 @@ filename = "README.md"
 filename = "docs/source/02_installation/01_installation.md"
 
 [[tool.bumpversion.files]]
-filename = "docs/source/03_getting_started/01_example_project.md"
+filename = "docs/source/03_quickstart/01_example_project.md"


### PR DESCRIPTION
## Description
Fix build https://github.com/Galileo-Galilei/kedro-mlflow/actions/runs/13020609952/job/36320216122

## Development notes
 Fix reference to 03_gettingstarted to 03_quickstart

## Checklist

- [ ] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
