### PR TITLE
:construction_worker: :zap: Improve github actions speed with uv and pytest-xdist

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,8 +23,12 @@ jobs:
       PYTHON_PACKAGE: kedro_mlflow
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Validate inputs
@@ -33,8 +37,8 @@ jobs:
     - name: Bump the version number  # bump2version is a maintained fork of original bumpversion
       id: bump_version
       run: |
-        pip install bump-my-version
-        bump-my-version bump ${{ github.event.inputs.version_part }}
+        uv tool install bump-my-version
+        uvx bump-my-version bump ${{ github.event.inputs.version_part }}
         echo "package_version=$(cat $PYTHON_PACKAGE/__init__.py | grep -Po  '\d+\.\d+\.\d+')" >> $GITHUB_OUTPUT
     - name: Update the CHANGELOG according to 'Keep a Changelog' guidelines
       uses: thomaseizinger/keep-a-changelog-new-release@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         uv venv
         uv pip install wheel
-        uv run python setup.py sdist bdist_wheel
+        uv run --no-project python setup.py sdist bdist_wheel
     - name: Set dynamically package version as output variable
       # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
       id: set_package_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # necessary to enable merging, all the history is needed
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Build package dist from source # A better way will be : https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ but pep 517 is still marked as experimental
       run: |
-        pip install wheel
-        python setup.py sdist bdist_wheel
+        uv venv
+        uv pip install wheel
+        uv run python setup.py sdist bdist_wheel
     - name: Set dynamically package version as output variable
       # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
       id: set_package_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,25 +21,29 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v3
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
+        uv venv
+        uv pip install .[test]
     - name: Check code formatting with ruff
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
       run: |
-        ruff format . --check
+        uv run ruff format . --check
     - name: Check import order and syntax with ruff
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
       run: |
-        ruff check .
+        uv run ruff check .
     - name: Test with pytest and generate coverage report
       run: |
-        pytest --cov=./ --cov-report=xml
+        uv run pytest --cov=./ --cov-report=xml
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # upload should occur only once in the loop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         uv run ruff check .
     - name: Test with pytest and generate coverage report
       run: |
-        uv run pytest --cov=./ --cov-report=xml
+        uv run --no-project pytest --cov=./ --cov-report=xml
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # upload should occur only once in the loop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
         uv run --no-project ruff check .
     - name: Test with pytest and generate coverage report
       run: |
-        uv pip install pytest-xdist
         uv run --no-project pytest --cov=./ --cov-report=xml -n auto
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
     - name: Check code formatting with ruff
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
       run: |
-        uv run ruff format . --check
+        uv run --no-project ruff format . --check
     - name: Check import order and syntax with ruff
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
       run: |
-        uv run ruff check .
+        uv run --no-project ruff check .
     - name: Test with pytest and generate coverage report
       run: |
         uv run --no-project pytest --cov=./ --cov-report=xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
         uv run --no-project ruff check .
     - name: Test with pytest and generate coverage report
       run: |
-        uv run --no-project pytest --cov=./ --cov-report=xml
+        uv pip install pytest-xdist
+        uv run --no-project pytest --cov=./ --cov-report=xml -n auto
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # upload should occur only once in the loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
--   :memo: Change documentation theme to [the pydata sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/#), and refacotr secion to make them clearer  ([#621](https://github.com/Galileo-Galilei/kedro-mlflow/pull/621))
+-   :memo: Change documentation theme to [the pydata sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/#), and refactor sections to make them clearer  ([#621](https://github.com/Galileo-Galilei/kedro-mlflow/pull/621))
 
 ## [0.14.0] - 2025-01-28
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kedro>=0.19.0, <0.19.11
+kedro>=0.19.0, <0.20.0
 kedro_datasets
 mlflow>=2.7.0, <3.0.0
 pydantic>=1.0.0, <3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kedro>=0.19.0, <0.20.0
+kedro>=0.19.0, <0.19.11
 kedro_datasets
 mlflow>=2.7.0, <3.0.0
 pydantic>=1.0.0, <3.0.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "pytest-cov>=2.8.0, <7.0.0",
             "pytest-lazy-fixtures>=1.0.0, <2.0.0",
             "pytest-mock>=3.1.0, <4.0.0",
+            "pytest-xdist>=3.0.0,<4.0.0",  # mess up the test readibility in the console but is much faster for the CI with "-n auto" option
             "ruff>=0.5.0,<0.9.0",  # ensure consistency with pre-commit
             "scikit-learn>=0.23.0, <1.7.0",
             "kedro-datasets[pandas.CSVDataSet]",


### PR DESCRIPTION
## Description

Improve github actions speed with uv instead of pip and pytest-xdist to parallelize test. 

## Development notes

- Modify all github action sto setup uv and then use "uv run" and "uv pip" everywhere
- use "-n auto" option when running pytest in the CI

The CI time has improved from [8'52''](https://github.com/Galileo-Galilei/kedro-mlflow/actions/runs/13020907537) to [3' 37''](https://github.com/Galileo-Galilei/kedro-mlflow/actions/runs/13219115337)

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- N/A Update the documentation to reflect the code changes
- N/A Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- NA Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
