### PR TITLE
:sparkles: Add configuration to disable autologging for Databricks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml ``to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with the plugin([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
+
 ## [0.14.3] - 2025-02-17
 
 ### Added

--- a/kedro_mlflow/config/kedro_mlflow_config.py
+++ b/kedro_mlflow/config/kedro_mlflow_config.py
@@ -48,6 +48,7 @@ class MlflowServerOptions(BaseModel):
 class DisableTrackingOptions(BaseModel):
     # mutable default is ok for pydantic : https://stackoverflow.com/questions/63793662/how-to-give-a-pydantic-list-field-a-default-value
     pipelines: List[str] = []
+    disable_autologging: bool = True
 
     class Config:
         extra = "forbid"
@@ -157,6 +158,12 @@ class KedroMlflowConfig(BaseModel):
         mlflow.set_registry_uri(self.server.mlflow_registry_uri)
 
         self._set_experiment()
+
+        if self.tracking.disable_tracking.disable_autologging is True:
+            # notice that we dont't pass 'self.tracking.disable_tracking.disable_autologging' directly
+            # because if it's false we just keep the default behaviour of the platform which is often True by default,
+            # except on Databricks
+            mlflow.autolog(disable=True)
 
     def _register_request_header_provider(self, context: KedroContext):
         # this is a specific trick to deal with expiring tokens for authentication, see https://github.com/Galileo-Galilei/kedro-mlflow/issues/357

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -31,6 +31,7 @@ tracking:
   # in a new mlflow run
 
   disable_tracking:
+    disable_autologging: True  # If True, we force autologging to be disabled. This is useful on databricks with autologging by default which conflicts with the plugin. If False, we keep the default behaviour which is disable by default anayway.
     pipelines: []
 
   experiment:
@@ -41,6 +42,7 @@ tracking:
     id: null # if `id` is None, a new run will be created
     name: null # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
     nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+
   params:
     dict_params:
       flatten: False  # if True, parameter which are dictionary will be splitted in multiple parameters when logged in mlflow, one for each key.

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -35,7 +35,10 @@ def test_mlflow_config_default(kedro_project):
             request_header_provider=dict(type=None, pass_context=False, init_kwargs={}),
         ),
         tracking=dict(
-            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
+            disable_tracking=dict(
+                pipelines=["my_disabled_pipeline"],
+                disable_autologging=True,
+            ),
             experiment=dict(name="fake_package", restore_if_deleted=True),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(
@@ -74,7 +77,10 @@ def test_mlflow_config_in_uninitialized_project(kedro_project, package_name):
             request_header_provider=dict(type=None, pass_context=False, init_kwargs={}),
         ),
         tracking=dict(
-            disable_tracking=dict(pipelines=[]),
+            disable_tracking=dict(
+                pipelines=[],
+                disable_autologging=True,
+            ),
             experiment=dict(name="fake_project", restore_if_deleted=True),
             run=dict(id=None, name=None, nested=True),
             params=dict(
@@ -101,7 +107,10 @@ def test_mlflow_config_with_no_experiment_name(kedro_project):
             request_header_provider=dict(type=None, pass_context=False, init_kwargs={}),
         ),
         tracking=dict(
-            disable_tracking=dict(pipelines=[]),
+            disable_tracking=dict(
+                pipelines=[],
+                disable_autologging=True,
+            ),
             experiment=dict(name="fake_project", restore_if_deleted=True),
             run=dict(id=None, name=None, nested=True),
             params=dict(
@@ -215,7 +224,7 @@ def test_mlflow_config_correctly_set(kedro_project, project_settings):
             request_header_provider=dict(type=None, pass_context=False, init_kwargs={}),
         ),
         tracking=dict(
-            disable_tracking=dict(pipelines=[]),
+            disable_tracking=dict(pipelines=[], disable_autologging=True),
             experiment=dict(name="fake_project", restore_if_deleted=True),
             run=dict(id=None, name=None, nested=True),
             params=dict(
@@ -238,7 +247,10 @@ def test_mlflow_config_interpolated_with_globals_resolver(monkeypatch, fake_proj
             request_header_provider=dict(type=None, pass_context=False, init_kwargs={}),
         ),
         tracking=dict(
-            disable_tracking=dict(pipelines=["my_disabled_pipeline"]),
+            disable_tracking=dict(
+                pipelines=["my_disabled_pipeline"],
+                disable_autologging=True,
+            ),
             experiment=dict(name="fake_package", restore_if_deleted=True),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -33,7 +33,7 @@ def test_mlflow_yml_rendering(template_mlflowyml):
     expected_config = KedroMlflowConfig.construct(
         project_path="fake/path",
         tracking=dict(
-            disable_tracking=dict(pipelines=[]),
+            disable_tracking=dict(pipelines=[], disable_autologging=False),
             experiment=dict(name="fake_project", restore_if_deleted=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -33,7 +33,7 @@ def test_mlflow_yml_rendering(template_mlflowyml):
     expected_config = KedroMlflowConfig.construct(
         project_path="fake/path",
         tracking=dict(
-            disable_tracking=dict(pipelines=[], disable_autologging=False),
+            disable_tracking=dict(pipelines=[], disable_autologging=True),
             experiment=dict(name="fake_project", restore_if_deleted=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),


### PR DESCRIPTION
## Description
Close #610

## Development notes
What have you changed, and how has this been tested?

- Add a configuration in ``mlflow.yml`` to disable autologging globally and set it to true by default. 
- Trigger it in ``KedroMlflowConfig.setup()``

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [X] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
