### PR TITLE
:sparkles: Enable passing kwargs to create_experiment from configuration, including artifact_location (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml `` to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with ``kedro-mlflow`` ([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
 - :sparkles: Add ``tracking.experiment.create_experiment_kwargs.artifact_location`` and ``tracking.experiment.create_experiment_kwargs.tags`` configuration options in ``mlflow.yml `` to enable advanced configuration of mlflow experiment created at runtime by ``kedro-mlflow`` ([[#557](https://github.com/Galileo-Galilei/kedro-mlflow/issues/557)]).
 
+### Fixed
+
+- :bug: Fix type annotations introduced in [#633](https://github.com/Galileo-Galilei/kedro-mlflow/pull/633) which are not compatible with ``python==3.9``.
+
 ## [0.14.3] - 2025-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml ``to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with the plugin([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
+- :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml `` to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with ``kedro-mlflow`` ([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
+- :sparkles: Add ``tracking.experiment.create_experiment_kwargs.artifact_location`` and ``tracking.experiment.create_experiment_kwargs.tags`` configuration options in ``mlflow.yml `` to enable advanced configuration of mlflow experiment created at runtime by ``kedro-mlflow`` ([[#557](https://github.com/Galileo-Galilei/kedro-mlflow/issues/557)]).
 
 ## [0.14.3] - 2025-02-17
 

--- a/docs/source/03_experiment_tracking/01_experiment_tracking/01_configuration.md
+++ b/docs/source/03_experiment_tracking/01_experiment_tracking/01_configuration.md
@@ -53,16 +53,21 @@ tracking:
   # in a new mlflow run
 
   disable_tracking:
+    disable_autologging: True  # If True, we force autologging to be disabled. This is useful on databricks with autologging by default which conflicts with the plugin. If False, we keep the default behaviour which is disable by default anayway.
     pipelines: []
 
   experiment:
     name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 
   run:
     id: null # if `id` is None, a new run will be created
     name: null # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
     nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+
   params:
     dict_params:
       flatten: False  # if True, parameter which are dictionary will be splitted in multiple parameters when logged in mlflow, one for each key.
@@ -175,11 +180,12 @@ Mlflow enable the user to create "experiments" to organize his work. The differe
 ```yaml
 tracking:
   experiment:
-    name: <your-experiment-name>  # by default, the name of your python package in your kedro project
+    name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 ```
-
-Note that by default, mlflow crashes if you try to start a run while you have not created the experiment first. `kedro-mlflow` has a `create` key (`True` by default) which forces the creation of the experiment if it does not exist. Set it to `False` to match mlflow default value.
 
 ### Configure the run
 
@@ -191,8 +197,8 @@ The `mlflow.yml` accepts the following keys:
 tracking:
   run:
     id: null # if `id` is None, a new run will be created
-    name: null # if `name` is None, pipeline name will be used for the run name
-    nested: True  # # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+    name: null # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
+    nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
 ```
 
 ```{tip}

--- a/docs/source/03_experiment_tracking/01_experiment_tracking/02_version_parameters.md
+++ b/docs/source/03_experiment_tracking/01_experiment_tracking/02_version_parameters.md
@@ -2,7 +2,7 @@
 
 ## Automatic parameters tracking
 
-Parameters tracking is automatic when the ``MlflowHook`` is added to [the hook list of the ``ProjectContext``](https://kedro-mlflow.readthedocs.io/en/latest/source/02_getting_started/01_installation/02_setup.html). The `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```Dict`` parameter](https://kedro-mlflow.readthedocs.io/en/latest/source/05_API/01_python_objects/02_Hooks.html).
+Parameters tracking is automatic when the ``MlflowHook`` is added to [the hook list of the ``ProjectContext``](https://kedro-mlflow.readthedocs.io/en/latest/source/02_getting_started/01_installation/02_setup.html). The `mlflow.yml` configuration file has a parameter called ``flatten_dict_params`` which enables to [log as distinct parameters the (key, value) pairs of a ```dict`` parameter](https://kedro-mlflow.readthedocs.io/en/latest/source/05_API/01_python_objects/02_Hooks.html).
 
 You **do not need any additional configuration** to benefit from parameters versioning.
 

--- a/docs/source/03_experiment_tracking/01_experiment_tracking/05_version_metrics.md
+++ b/docs/source/03_experiment_tracking/01_experiment_tracking/05_version_metrics.md
@@ -172,7 +172,7 @@ my_model_metrics:
 Let assume that you have node which doesn't have any inputs and returns dictionary with metrics to log:
 
 ```python
-def metrics_node() -> Dict[str, Union[float, List[float]]]:
+def metrics_node() -> dict[str, Union[float, list[float]]]:
     return {
         "metric1": {"value": 1.1, "step": 1},
         "metric2": [{"value": 1.1, "step": 1}, {"value": 1.2, "step": 2}],
@@ -181,8 +181,8 @@ def metrics_node() -> Dict[str, Union[float, List[float]]]:
 
 As you can see above, ``kedro_mlflow.io.metrics.MlflowMetricsHistoryDataset`` can take metrics as:
 
-- ``Dict[str, key]``
-- ``List[Dict[str, key]]``
+- ``[str, key]``
+- ``list[[str, key]]``
 
 To store metrics we need to define metrics dataset in Kedro Catalog:
 

--- a/docs/source/04_pipeline_as_model/01_pipeline_as_custom_model/02_scikit_learn_like_pipeline.md
+++ b/docs/source/04_pipeline_as_model/01_pipeline_as_custom_model/02_scikit_learn_like_pipeline.md
@@ -23,7 +23,7 @@ You can configure your project as follows:
     from kedro_mlflow_tutorial.pipelines.ml_app.pipeline import create_ml_pipeline
 
 
-    def register_pipelines(self) -> Dict[str, Pipeline]:
+    def register_pipelines(self) -> [str, Pipeline]:
         ml_pipeline = create_ml_pipeline()
         training_pipeline_ml = pipeline_ml_factory(
             training=ml_pipeline.only_nodes_with_tags(

--- a/docs/source/04_pipeline_as_model/02_framework_ml/03_framework_solutions.md
+++ b/docs/source/04_pipeline_as_model/02_framework_ml/03_framework_solutions.md
@@ -24,7 +24,7 @@ from kedro_mlflow_tutorial.pipelines.ml_app.pipeline import create_ml_pipeline
 
 class ProjectHooks:
     @hook_impl
-    def register_pipelines(self) -> Dict[str, Pipeline]:
+    def register_pipelines(self) -> [str, Pipeline]:
         ml_pipeline = create_ml_pipeline()
 
         # convert your two pipelines to a PipelinML object

--- a/docs/source/05_API/01_python_objects/01_Datasets.md
+++ b/docs/source/05_API/01_python_objects/01_Datasets.md
@@ -62,8 +62,8 @@ The ``MlflowModelTrackingDataset`` accepts the following arguments:
 - run_id (Optional[str], optional): MLflow run ID to use to load the model from or save the model to. It plays the same role as "filepath" for standard mlflow datasets. Defaults to None.
 - artifact_path (str, optional): the run relative path to the model.
 - pyfunc_workflow (str, optional): Either `python_model` or `loader_module`.See [mlflow workflows](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows).
-- load_args (Dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
-- save_args (Dict[str, Any], optional): Arguments to `log_model` function from specified `flavor`. Defaults to None.
+- load_args (dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
+- save_args (dict[str, Any], optional): Arguments to `log_model` function from specified `flavor`. Defaults to None.
 
 You can either only specify the flavor:
 
@@ -122,8 +122,8 @@ The ``MlflowModelLocalFileSystemDataset`` accepts the following arguments:
 - flavor (str): Built-in or custom MLflow model flavor module. Must be Python-importable.
 - filepath (str): Path to store the dataset locally.
 - pyfunc_workflow (str, optional): Either `python_model` or `loader_module`. See [mlflow workflows](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows).
-- load_args (Dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
-- save_args (Dict[str, Any], optional): Arguments to `save_model` function from specified `flavor`. Defaults to None.
+- load_args (dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
+- save_args (dict[str, Any], optional): Arguments to `save_model` function from specified `flavor`. Defaults to None.
 - version (Version, optional): Kedro version to use. Defaults to None.
 
 The use is very similar to ``MlflowModelTrackingDataset``, but you have to specify a local ``filepath`` instead of a `run_id`:
@@ -168,7 +168,7 @@ The ``MlflowModelRegistryDataset`` accepts the following arguments:
 - ``alias`` (str): A valid alias, which is used instead of stage to filter model since mlflow 2.9.0. Will raise an error if both ``stage_or_version`` and ``alias`` are provided.
 - ``flavor`` (str): Built-in or custom MLflow model flavor module. Must be Python-importable.
 - ``pyfunc_workflow`` (str, optional): Either `python_model` or `loader_module`. See [mlflow workflows](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows).
-- ``load_args`` (Dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
+- ``load_args`` (dict[str, Any], optional): Arguments to `load_model` function from specified `flavor`. Defaults to None.
 
 We assume you have registered a mlflow model first, either [with the ``MlflowClient``](https://mlflow.org/docs/latest/model-registry.html#adding-an-mlflow-model-to-the-model-registry) or [within the mlflow ui](https://mlflow.org/docs/latest/model-registry.html#ui-workflow), e.g. :
 

--- a/docs/source/05_API/01_python_objects/03_Pipelines.md
+++ b/docs/source/05_API/01_python_objects/03_Pipelines.md
@@ -14,7 +14,7 @@ Example within kedro template:
 from PYTHON_PACKAGE.pipelines import data_science as ds
 
 
-def create_pipelines(**kwargs) -> Dict[str, Pipeline]:
+def create_pipelines(**kwargs) -> dict[str, Pipeline]:
     data_science_pipeline = ds.create_pipeline()
     training_pipeline = pipeline_ml_factory(
         training=data_science_pipeline.only_nodes_with_tags(

--- a/kedro_mlflow/framework/cli/cli.py
+++ b/kedro_mlflow/framework/cli/cli.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from pathlib import Path
 from platform import python_version
 from tempfile import TemporaryDirectory
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import click
 import mlflow
@@ -295,7 +295,7 @@ def modelify(
     flag_infer_input_example: Optional[bool],
     run_id: Optional[str],
     run_name: Optional[str],
-    copy_mode: Optional[Union[str, Dict[str, str]]],
+    copy_mode: Optional[Union[str, dict[str, str]]],
     artifact_path: str,
     code_path: str,
     conda_env: Optional[str],

--- a/kedro_mlflow/framework/hooks/mlflow_hook.py
+++ b/kedro_mlflow/framework/hooks/mlflow_hook.py
@@ -3,7 +3,7 @@ import re
 from logging import Logger, getLogger
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import mlflow
 from kedro.config import MissingConfigException
@@ -145,9 +145,9 @@ class MlflowHook:
     def after_catalog_created(
         self,
         catalog: DataCatalog,
-        conf_catalog: Dict[str, Any],
-        conf_creds: Dict[str, Any],
-        feed_dict: Dict[str, Any],
+        conf_catalog: dict[str, Any],
+        conf_creds: dict[str, Any],
+        feed_dict: dict[str, Any],
         save_version: str,
         load_versions: str,
     ):
@@ -197,7 +197,7 @@ class MlflowHook:
 
     @hook_impl
     def before_pipeline_run(
-        self, run_params: Dict[str, Any], pipeline: Pipeline, catalog: DataCatalog
+        self, run_params: dict[str, Any], pipeline: Pipeline, catalog: DataCatalog
     ) -> None:
         """Hook to be invoked before a pipeline runs.
         Args:
@@ -208,14 +208,14 @@ class MlflowHook:
                     "project_path": str,
                     "env": str,
                     "kedro_version": str,
-                    "tags": Optional[List[str]],
-                    "from_nodes": Optional[List[str]],
-                    "to_nodes": Optional[List[str]],
-                    "node_names": Optional[List[str]],
-                    "from_inputs": Optional[List[str]],
-                    "load_versions": Optional[List[str]],
+                    "tags": Optional[list[str]],
+                    "from_nodes": Optional[list[str]],
+                    "to_nodes": Optional[list[str]],
+                    "node_names": Optional[list[str]],
+                    "from_inputs": Optional[list[str]],
+                    "load_versions": Optional[list[str]],
                     "pipeline_name": str,
-                    "extra_params": Optional[Dict[str, Any]],
+                    "extra_params": Optional[dict[str, Any]],
                 }
             pipeline: The ``Pipeline`` that will be run.
             catalog: The ``DataCatalog`` to be used during the run.
@@ -282,7 +282,7 @@ class MlflowHook:
 
     @hook_impl
     def before_node_run(
-        self, node: Node, catalog: DataCatalog, inputs: Dict[str, Any], is_async: bool
+        self, node: Node, catalog: DataCatalog, inputs: dict[str, Any], is_async: bool
     ) -> None:
         """Hook to be invoked before a node runs.
         This hook logs all the parameters of the nodes in mlflow.
@@ -342,7 +342,7 @@ class MlflowHook:
             for k, v in params_inputs.items():
                 self._log_param(k, v)
 
-    def _log_param(self, name: str, value: Union[Dict, int, bool, str]) -> None:
+    def _log_param(self, name: str, value: Union[dict, int, bool, str]) -> None:
         str_value = str(value)
         str_value_length = len(str_value)
         if str_value_length <= MAX_PARAM_VAL_LENGTH:
@@ -368,7 +368,7 @@ class MlflowHook:
     @hook_impl
     def after_pipeline_run(
         self,
-        run_params: Dict[str, Any],
+        run_params: dict[str, Any],
         pipeline: Pipeline,
         catalog: DataCatalog,
     ) -> None:
@@ -381,14 +381,14 @@ class MlflowHook:
                     "project_path": str,
                     "env": str,
                     "kedro_version": str,
-                    "tags": Optional[List[str]],
-                    "from_nodes": Optional[List[str]],
-                    "to_nodes": Optional[List[str]],
-                    "node_names": Optional[List[str]],
-                    "from_inputs": Optional[List[str]],
-                    "load_versions": Optional[List[str]],
+                    "tags": Optional[list[str]],
+                    "from_nodes": Optional[list[str]],
+                    "to_nodes": Optional[list[str]],
+                    "node_names": Optional[list[str]],
+                    "from_inputs": Optional[list[str]],
+                    "load_versions": Optional[list[str]],
                     "pipeline_name": str,
-                    "extra_params": Optional[Dict[str, Any]],
+                    "extra_params": Optional[dict[str, Any]],
                 }
             pipeline: The ``Pipeline`` that was run.
             catalog: The ``DataCatalog`` used during the run.
@@ -451,7 +451,7 @@ class MlflowHook:
     def on_pipeline_error(
         self,
         error: Exception,
-        run_params: Dict[str, Any],
+        run_params: dict[str, Any],
         pipeline: Pipeline,
         catalog: DataCatalog,
     ):
@@ -467,14 +467,14 @@ class MlflowHook:
                      "project_path": str,
                      "env": str,
                      "kedro_version": str,
-                     "tags": Optional[List[str]],
-                     "from_nodes": Optional[List[str]],
-                     "to_nodes": Optional[List[str]],
-                     "node_names": Optional[List[str]],
-                     "from_inputs": Optional[List[str]],
-                     "load_versions": Optional[List[str]],
+                     "tags": Optional[list[str]],
+                     "from_nodes": Optional[list[str]],
+                     "to_nodes": Optional[list[str]],
+                     "node_names": Optional[list[str]],
+                     "from_inputs": Optional[list[str]],
+                     "load_versions": Optional[list[str]],
                      "pipeline_name": str,
-                     "extra_params": Optional[Dict[str, Any]]
+                     "extra_params": Optional[dict[str, Any]]
                    }
             pipeline: (Not used) The ``Pipeline`` that will was run.
             catalog: (Not used) The ``DataCatalog`` used during the run.

--- a/kedro_mlflow/framework/hooks/utils.py
+++ b/kedro_mlflow/framework/hooks/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from kedro_mlflow.config.kedro_mlflow_config import KedroMlflowConfig
 
 
@@ -43,7 +41,7 @@ def _generate_kedro_command(
     return kedro_cmd
 
 
-def _flatten_dict(d: Dict, recursive: bool = True, sep: str = ".") -> Dict:
+def _flatten_dict(d: dict, recursive: bool = True, sep: str = ".") -> dict:
     def expand(key, value):
         if isinstance(value, dict):
             new_value = (

--- a/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
+++ b/kedro_mlflow/io/artifacts/mlflow_artifact_dataset.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Optional, Union
 
 import mlflow
 from kedro.io import AbstractVersionedDataset
@@ -15,11 +15,11 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
 
     def __new__(
         cls,
-        dataset: Union[str, Dict],
+        dataset: Union[str, dict],
         run_id: str = None,
         artifact_path: str = None,
-        credentials: Dict[str, Any] = None,
-        metadata: Dict[str, Any] | None = None,
+        credentials: dict[str, Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         dataset_obj, dataset_args = parse_dataset_definition(config=dataset)
 
@@ -169,7 +169,7 @@ class MlflowArtifactDataset(AbstractVersionedDataset):
         """
         pass
 
-    def _describe(self) -> Dict[str, Any]:  # pragma: no cover
+    def _describe(self) -> dict[str, Any]:  # pragma: no cover
         """
         MlflowArtifactDataset is a factory for DataSet
         and consequently does not implements abtracts methods

--- a/kedro_mlflow/io/metrics/mlflow_abstract_metric_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_abstract_metric_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Optional, Union
 
 import mlflow
 from kedro.io import AbstractDataset
@@ -10,9 +10,9 @@ class MlflowAbstractMetricDataset(AbstractDataset):
         self,
         key: str = None,
         run_id: str = None,
-        load_args: Dict[str, Any] = None,
-        save_args: Dict[str, Any] = None,
-        metadata: Dict[str, Any] | None = None,
+        load_args: dict[str, Any] = None,
+        save_args: dict[str, Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         """Initialise MlflowMetricsHistoryDataset.
 
@@ -81,11 +81,11 @@ class MlflowAbstractMetricDataset(AbstractDataset):
         flag_exist = self.key in run.data.metrics.keys() if run else False
         return flag_exist
 
-    def _describe(self) -> Dict[str, Any]:
+    def _describe(self) -> dict[str, Any]:
         """Describe MLflow metrics dataset.
 
         Returns:
-            Dict[str, Any]: Dictionary with MLflow metrics dataset description.
+            dict[str, Any]: dictionary with MLflow metrics dataset description.
         """
         return {
             "key": self.key,

--- a/kedro_mlflow/io/metrics/mlflow_metric_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_metric_dataset.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Optional
 
 from mlflow.tracking import MlflowClient
 
@@ -16,9 +16,9 @@ class MlflowMetricDataset(MlflowAbstractMetricDataset):
         self,
         key: str = None,
         run_id: str = None,
-        load_args: Dict[str, Any] = None,
-        save_args: Dict[str, Any] = None,
-        metadata: Dict[str, Any] | None = None,
+        load_args: dict[str, Any] = None,
+        save_args: dict[str, Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         """Initialise MlflowMetricDataset.
         Args:

--- a/kedro_mlflow/io/metrics/mlflow_metric_history_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_metric_history_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Optional, Union
 
 from mlflow.tracking import MlflowClient
 
@@ -12,9 +12,9 @@ class MlflowMetricHistoryDataset(MlflowAbstractMetricDataset):
         self,
         key: str = None,
         run_id: str = None,
-        load_args: Dict[str, Any] = None,
-        save_args: Dict[str, Any] = None,
-        metadata: Dict[str, Any] | None = None,
+        load_args: dict[str, Any] = None,
+        save_args: dict[str, Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         """Initialise MlflowMetricDataset.
         Args:
@@ -51,7 +51,7 @@ class MlflowMetricHistoryDataset(MlflowAbstractMetricDataset):
 
     def _save(
         self,
-        data: Union[List[int], Dict[int, float], List[Dict[str, Union[float, str]]]],
+        data: Union[list[int], dict[int, float], list[dict[str, Union[float, str]]]],
     ):
         if self._logging_activated:
             self._validate_run_id()

--- a/kedro_mlflow/io/metrics/mlflow_metrics_history_dataset.py
+++ b/kedro_mlflow/io/metrics/mlflow_metrics_history_dataset.py
@@ -1,14 +1,14 @@
 from functools import partial
 from itertools import chain
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Generator, Optional, Tuple, Union
 
 import mlflow
 from kedro.io import AbstractDataset, DatasetError
 from mlflow.tracking import MlflowClient
 
-MetricItem = Union[Dict[str, float], List[Dict[str, float]]]
+MetricItem = Union[dict[str, float], list[dict[str, float]]]
 MetricTuple = Tuple[str, float, int]
-MetricsDict = Dict[str, MetricItem]
+Metricsdict = dict[str, MetricItem]
 
 
 class MlflowMetricsHistoryDataset(AbstractDataset):
@@ -18,7 +18,7 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
         self,
         run_id: str = None,
         prefix: Optional[str] = None,
-        metadata: Dict[str, Any] | None = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         """Initialise MlflowMetricsHistoryDataset.
 
@@ -66,11 +66,11 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
             raise ValueError(f"_logging_activated must be a boolean, got {type(flag)}")
         self.__logging_activated = flag
 
-    def _load(self) -> MetricsDict:
+    def _load(self) -> Metricsdict:
         """Load MlflowMetricDataSet.
 
         Returns:
-            Dict[str, Union[int, float]]: Dictionary with MLflow metrics dataset.
+            dict[str, Union[int, float]]: dictionary with MLflow metrics dataset.
         """
         client = MlflowClient()
 
@@ -89,11 +89,11 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
 
         return dataset_metrics
 
-    def _save(self, data: MetricsDict) -> None:
+    def _save(self, data: Metricsdict) -> None:
         """Save given MLflow metrics dataset and log it in MLflow as metrics.
 
         Args:
-            data (MetricsDict): MLflow metrics dataset.
+            data (Metricsdict): MLflow metrics dataset.
         """
         client = MlflowClient()
         try:
@@ -128,11 +128,11 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
         # )
         return any(self._is_dataset_metric(x) for x in all_metrics_keys)
 
-    def _describe(self) -> Dict[str, Any]:
+    def _describe(self) -> dict[str, Any]:
         """Describe MLflow metrics dataset.
 
         Returns:
-            Dict[str, Any]: Dictionary with MLflow metrics dataset description.
+            dict[str, Any]: dictionary with MLflow metrics dataset description.
         """
         return {
             "run_id": self._run_id,
@@ -149,16 +149,16 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
 
     # @staticmethod
     # def _update_metric(
-    #     metrics: List[mlflow.entities.Metric], dataset: MetricsDict = {}
-    # ) -> MetricsDict:
+    #     metrics: list[mlflow.entities.Metric], dataset: Metricsdict = {}
+    # ) -> Metricsdict:
     #     """Update metric in given dataset.
 
     #     Args:
-    #         metrics (List[mlflow.entities.Metric]): List with MLflow metric objects.
-    #         dataset (MetricsDict): Dictionary contains MLflow metrics dataset.
+    #         metrics (list[mlflow.entities.Metric]): list with MLflow metric objects.
+    #         dataset (Metricsdict): dictionary contains MLflow metrics dataset.
 
     #     Returns:
-    #         MetricsDict: Dictionary with MLflow metrics dataset.
+    #         Metricsdict: dictionary with MLflow metrics dataset.
     #     """
     #     for metric in metrics:
     #         metric_dict = {"step": metric.step, "value": metric.value}
@@ -173,13 +173,13 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
 
     @staticmethod
     def _convert_metric_history_to_list_or_dict(
-        metrics: List[mlflow.entities.Metric],
-    ) -> Dict[str, Dict[str, Union[float, List[float]]]]:
+        metrics: list[mlflow.entities.Metric],
+    ) -> dict[str, dict[str, Union[float, list[float]]]]:
         """Convert Mlflow metrics objects from MlflowClient().get_metric_history(run_id, key)
         to a list [{'step': x, 'value': y}, {'step': ..., 'value': ...}]
 
         Args:
-            metrics (List[mlflow.entities.Metric]): A list of MLflow Metrics retrieved from the run history
+            metrics (list[mlflow.entities.Metric]): A list of MLflow Metrics retrieved from the run history
         """
         metrics_as_list = [
             {"step": metric.step, "value": metric.value} for metric in metrics
@@ -203,7 +203,7 @@ class MlflowMetricsHistoryDataset(AbstractDataset):
             value (MetricItem): Metric value
 
         Returns:
-            List[MetricTuple]: List with metrics as tuples.
+            list[MetricTuple]: list with metrics as tuples.
         """
         if self._prefix:
             key = f"{self._prefix}.{key}"

--- a/kedro_mlflow/io/models/mlflow_abstract_model_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_abstract_model_dataset.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from kedro.io import AbstractVersionedDataset, Version
 from kedro.io.core import DatasetError
@@ -17,10 +17,10 @@ class MlflowAbstractModelDataSet(AbstractVersionedDataset):
         filepath: str,
         flavor: str,
         pyfunc_workflow: Optional[str] = None,
-        load_args: Dict[str, Any] = None,
-        save_args: Dict[str, Any] = None,
+        load_args: dict[str, Any] = None,
+        save_args: dict[str, Any] = None,
         version: Version = None,
-        metadata: Dict[str, Any] | None = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize the Kedro MlflowAbstractModelDataSet.
 
@@ -35,9 +35,9 @@ class MlflowAbstractModelDataSet(AbstractVersionedDataset):
                 Must be Python-importable.
             pyfunc_workflow (str, optional): Either `python_model` or `loader_module`.
                 See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows.
-            load_args (Dict[str, Any], optional): Arguments to `load_model`
+            load_args (dict[str, Any], optional): Arguments to `load_model`
                 function from specified `flavor`. Defaults to {}.
-            save_args (Dict[str, Any], optional): Arguments to `log_model`
+            save_args (dict[str, Any], optional): Arguments to `log_model`
                 function from specified `flavor`. Defaults to {}.
             version (Version, optional): Specific version to load.
             metadata: Any arbitrary metadata.
@@ -100,7 +100,7 @@ class MlflowAbstractModelDataSet(AbstractVersionedDataset):
 
     # TODO: check with Kajetan what was originally intended here
     # @classmethod
-    # def _parse_args(cls, kwargs_dict: Dict[str, Any]) -> Dict[str, Any]:
+    # def _parse_args(cls, kwargs_dict: dict[str, Any]) -> dict[str, Any]:
     #     parsed_kargs = {}
     #     for key, value in kwargs_dict.items():
     #         if key.endswith("_args"):

--- a/kedro_mlflow/io/models/mlflow_model_local_filesystem_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_model_local_filesystem_dataset.py
@@ -1,6 +1,6 @@
 import shutil
 from os.path import exists
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from kedro.io import Version
 
@@ -17,11 +17,11 @@ class MlflowModelLocalFileSystemDataset(MlflowAbstractModelDataSet):
         filepath: str,
         flavor: str,
         pyfunc_workflow: Optional[str] = None,
-        load_args: Dict[str, Any] = None,
-        save_args: Dict[str, Any] = None,
-        log_args: Dict[str, Any] = None,
+        load_args: dict[str, Any] = None,
+        save_args: dict[str, Any] = None,
+        log_args: dict[str, Any] = None,
         version: Version = None,
-        metadata: Dict[str, Any] | None = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize the Kedro MlflowModelDataSet.
 
@@ -36,9 +36,9 @@ class MlflowModelLocalFileSystemDataset(MlflowAbstractModelDataSet):
             filepath (str): Path to store the dataset locally.
             pyfunc_workflow (str, optional): Either `python_model` or `loader_module`.
                 See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows.
-            load_args (Dict[str, Any], optional): Arguments to `load_model`
+            load_args (dict[str, Any], optional): Arguments to `load_model`
                 function from specified `flavor`. Defaults to None.
-            save_args (Dict[str, Any], optional): Arguments to `save_model`
+            save_args (dict[str, Any], optional): Arguments to `save_model`
                 function from specified `flavor`. Defaults to None.
             version (Version, optional): Kedro version to use. Defaults to None.
             metadata: Any arbitrary metadata.
@@ -90,7 +90,7 @@ class MlflowModelLocalFileSystemDataset(MlflowAbstractModelDataSet):
             # model object and second is the path.
             self._mlflow_model_module.save_model(model, save_path, **self._save_args)
 
-    def _describe(self) -> Dict[str, Any]:
+    def _describe(self) -> dict[str, Any]:
         return dict(
             filepath=self._filepath,
             flavor=self._flavor,

--- a/kedro_mlflow/io/models/mlflow_model_registry_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_model_registry_dataset.py
@@ -1,5 +1,5 @@
 from logging import Logger, getLogger
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from kedro.io.core import DatasetError
 
@@ -18,8 +18,8 @@ class MlflowModelRegistryDataset(MlflowAbstractModelDataSet):
         alias: Optional[str] = None,
         flavor: Optional[str] = "mlflow.pyfunc",
         pyfunc_workflow: Optional[str] = "python_model",
-        load_args: Optional[Dict[str, Any]] = None,
-        metadata: Dict[str, Any] | None = None,
+        load_args: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize the Kedro MlflowModelRegistryDataset.
 
@@ -36,7 +36,7 @@ class MlflowModelRegistryDataset(MlflowAbstractModelDataSet):
                 Must be Python-importable.
             pyfunc_workflow (str, optional): Either `python_model` or `loader_module`.
                 See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows.
-            load_args (Dict[str, Any], optional): Arguments to `load_model`
+            load_args (dict[str, Any], optional): Arguments to `load_model`
                 function from specified `flavor`. Defaults to None.
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
@@ -103,7 +103,7 @@ class MlflowModelRegistryDataset(MlflowAbstractModelDataSet):
             "The 'save' method is not implemented for MlflowModelRegistryDataset. You can pass 'registered_model_name' argument in 'MLflowModelTrackingDataset(..., save_args={registered_model_name='my_model'}' to save and register a model in the same step. "
         )
 
-    def _describe(self) -> Dict[str, Any]:
+    def _describe(self) -> dict[str, Any]:
         return dict(
             model_uri=self.model_uri,
             model_name=self.model_name,

--- a/kedro_mlflow/io/models/mlflow_model_tracking_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_model_tracking_dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import mlflow
 from kedro.io.core import DatasetError
@@ -17,9 +17,9 @@ class MlflowModelTrackingDataset(MlflowAbstractModelDataSet):
         run_id: Optional[str] = None,
         artifact_path: Optional[str] = "model",
         pyfunc_workflow: Optional[str] = None,
-        load_args: Optional[Dict[str, Any]] = None,
-        save_args: Optional[Dict[str, Any]] = None,
-        metadata: Dict[str, Any] | None = None,
+        load_args: Optional[dict[str, Any]] = None,
+        save_args: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize the Kedro MlflowModelDataSet.
 
@@ -37,9 +37,9 @@ class MlflowModelTrackingDataset(MlflowAbstractModelDataSet):
                 the model.
             pyfunc_workflow (str, optional): Either `python_model` or `loader_module`.
                 See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#workflows.
-            load_args (Dict[str, Any], optional): Arguments to `load_model`
+            load_args (dict[str, Any], optional): Arguments to `load_model`
                 function from specified `flavor`. Defaults to None.
-            save_args (Dict[str, Any], optional): Arguments to `log_model`
+            save_args (dict[str, Any], optional): Arguments to `log_model`
                 function from specified `flavor`. Defaults to None.
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
@@ -137,7 +137,7 @@ class MlflowModelTrackingDataset(MlflowAbstractModelDataSet):
                 model, self._artifact_path, **self._save_args
             )
 
-    def _describe(self) -> Dict[str, Any]:
+    def _describe(self) -> dict[str, Any]:
         return dict(
             flavor=self._flavor,
             run_id=self._run_id,

--- a/kedro_mlflow/mlflow/kedro_pipeline_model.py
+++ b/kedro_mlflow/mlflow/kedro_pipeline_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from kedro.framework.hooks import _create_hook_manager
 from kedro.io import DataCatalog, MemoryDataset
@@ -20,7 +20,7 @@ class KedroPipelineModel(PythonModel):
         catalog: DataCatalog,
         input_name: str,
         runner: Optional[AbstractRunner] = None,
-        copy_mode: Optional[Union[Dict[str, str], str]] = "assign",
+        copy_mode: Optional[Union[dict[str, str], str]] = "assign",
     ):
         """[summary]
 
@@ -35,7 +35,7 @@ class KedroPipelineModel(PythonModel):
             AbstractRunner to use. Defaults to SequentialRunner if
             None.
 
-            copy_mode (Optional[Union[Dict[str,str], str]]):
+            copy_mode (Optional[Union[dict[str,str], str]]):
             The copy_mode of each DataSet of the catalog
             when reconstructing the DataCatalog in memory.
             The default is "assign".

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -1,5 +1,5 @@
 from logging import Logger, getLogger
-from typing import Dict, Iterable, Optional, Union
+from typing import Iterable, Optional, Union
 
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
@@ -43,8 +43,8 @@ class PipelineML(Pipeline):
         tags: Optional[Union[str, Iterable[str]]] = None,
         inference: Pipeline,
         input_name: str,
-        kpm_kwargs: Optional[Dict[str, str]] = None,
-        log_model_kwargs: Optional[Dict[str, str]] = None,
+        kpm_kwargs: Optional[dict[str, str]] = None,
+        log_model_kwargs: Optional[dict[str, str]] = None,
     ):
         """Store all necessary information for calling mlflow.log_model in the pipeline.
 

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -36,6 +36,9 @@ tracking:
 
   experiment:
     name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 
   run:

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -39,7 +39,11 @@ def test_mlflow_config_default(kedro_project):
                 pipelines=["my_disabled_pipeline"],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_package", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_package",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(
                 dict_params=dict(
@@ -81,7 +85,11 @@ def test_mlflow_config_in_uninitialized_project(kedro_project, package_name):
                 pipelines=[],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -111,7 +119,11 @@ def test_mlflow_config_with_no_experiment_name(kedro_project):
                 pipelines=[],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -225,7 +237,11 @@ def test_mlflow_config_correctly_set(kedro_project, project_settings):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[], disable_autologging=True),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -251,7 +267,11 @@ def test_mlflow_config_interpolated_with_globals_resolver(monkeypatch, fake_proj
                 pipelines=["my_disabled_pipeline"],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_package", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_package",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(
                 dict_params=dict(
@@ -318,7 +338,11 @@ class CustomRequestHeaderProvider(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -377,7 +401,11 @@ class CustomRequestHeaderProviderInitKwargs(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -440,7 +468,11 @@ class CustomRequestHeaderProviderInitKwargsKedroContext(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -495,7 +527,11 @@ class BadCustomRequestHeaderProvider():
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(

--- a/tests/framework/hooks/test_hook_deactivate_tracking.py
+++ b/tests/framework/hooks/test_hook_deactivate_tracking.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import pytest
 import toml
@@ -39,13 +39,13 @@ def kedro_project_path(tmp_path):
     return tmp_path / MOCK_PACKAGE_NAME
 
 
-def _write_yaml(filepath: Path, config: Dict):
+def _write_yaml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
     yaml_str = yaml.dump(config)
     filepath.write_text(yaml_str)
 
 
-def _write_toml(filepath: Path, config: Dict):
+def _write_toml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
     toml_str = toml.dumps(config)
     filepath.write_text(toml_str)
@@ -132,9 +132,9 @@ class DummyProjectHooks:
     @hook_impl
     def register_catalog(
         self,
-        catalog: Optional[Dict[str, Dict[str, Any]]],
-        credentials: Dict[str, Dict[str, Any]],
-        load_versions: Dict[str, str],
+        catalog: Optional[dict[str, dict[str, Any]]],
+        credentials: dict[str, dict[str, Any]],
+        load_versions: dict[str, str],
         save_version: str,
     ) -> DataCatalog:
         return DataCatalog.from_config(

--- a/tests/framework/hooks/test_hook_log_parameters.py
+++ b/tests/framework/hooks/test_hook_log_parameters.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Dict
 
 import mlflow
 import pytest
@@ -15,7 +14,7 @@ from mlflow.utils.validation import MAX_PARAM_VAL_LENGTH
 from kedro_mlflow.framework.hooks import MlflowHook
 
 
-def _write_yaml(filepath: Path, config: Dict):
+def _write_yaml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
     yaml_str = yaml.dump(config)
     filepath.write_text(yaml_str)

--- a/tests/framework/hooks/test_hook_on_pipeline_error.py
+++ b/tests/framework/hooks/test_hook_on_pipeline_error.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import mlflow
 import pytest
@@ -23,9 +23,9 @@ class DummyProjectHooks:
     @hook_impl
     def register_catalog(
         self,
-        catalog: Optional[Dict[str, Dict[str, Any]]],
-        credentials: Dict[str, Dict[str, Any]],
-        load_versions: Dict[str, str],
+        catalog: Optional[dict[str, dict[str, Any]]],
+        credentials: dict[str, dict[str, Any]],
+        load_versions: dict[str, str],
         save_version: str,
     ) -> DataCatalog:
         return DataCatalog.from_config(

--- a/tests/io/metrics/test_mlflow_metrics_dataset.py
+++ b/tests/io/metrics/test_mlflow_metrics_dataset.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import mlflow
 import pytest
@@ -10,7 +10,7 @@ from kedro_mlflow.io.metrics import MlflowMetricsHistoryDataset
 
 
 def assert_are_metrics_logged(
-    data: Dict[str, Union[float, List[float]]],
+    data: dict[str, Union[float, list[float]]],
     client: MlflowClient,
     run_id: str,
     prefix: Optional[str] = None,
@@ -18,7 +18,7 @@ def assert_are_metrics_logged(
     """Helper function which checks if given metrics where logged.
 
     Args:
-        data: (Dict[str, Union[float, List[float]]]): Logged metrics.
+        data: (dict[str, Union[float, list[float]]]): Logged metrics.
         client: (MlflowClient): MLflow client instance.
         run_id: (str): id of run where data was logged.
         prefix: (Optional[str])

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -34,7 +34,11 @@ def test_mlflow_yml_rendering(template_mlflowyml):
         project_path="fake/path",
         tracking=dict(
             disable_tracking=dict(pipelines=[], disable_autologging=True),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
                 long_params_strategy="fail",


### PR DESCRIPTION
## Description

Close #557

## Development notes

- add a configuration option for ``create_experiment_kwargs`` in ``KedroMLflowConfig`` and mlflow.yml
- update ``KedroMLflowConfig.setup()`` to manually create the eperiment instead of delegating it to ``mlflow.set_experiment()``
- (UNRELATED) Replace all ``Dict[str,Any] |None`` introduced by #633 by ``Optional[dict[str,any]]`` to ensure compatiblity with python 3.9
- (UNRELATED) Replace all ``Dict`` and ``List`` from ``typing`` by native ``dict`` and ``list``

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
