### PR TITLE
:sparkles: Enable passing kwargs to create_experiment from configuration, including artifact_location (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml ``to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with the plugin([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
+- :sparkles: Add the ``tracking.disable_tracking.disable_autologging`` configuration option in ``mlflow.yml `` to disable autologging by default. This simplify the workflow for Databricks users who have autologging activated by default, which conflicts with ``kedro-mlflow`` ([[#610](https://github.com/Galileo-Galilei/kedro-mlflow/issues/610)]).
+- :sparkles: Add ``tracking.experiment.create_experiment_kwargs.artifact_location`` and ``tracking.experiment.create_experiment_kwargs.tags`` configuration options in ``mlflow.yml `` to enable advanced configuration of mlflow experiment created at runtime by ``kedro-mlflow`` ([[#557](https://github.com/Galileo-Galilei/kedro-mlflow/issues/557)]).
 
 ## [0.14.3] - 2025-02-17
 

--- a/docs/source/03_experiment_tracking/01_experiment_tracking/01_configuration.md
+++ b/docs/source/03_experiment_tracking/01_experiment_tracking/01_configuration.md
@@ -53,16 +53,21 @@ tracking:
   # in a new mlflow run
 
   disable_tracking:
+    disable_autologging: True  # If True, we force autologging to be disabled. This is useful on databricks with autologging by default which conflicts with the plugin. If False, we keep the default behaviour which is disable by default anayway.
     pipelines: []
 
   experiment:
     name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 
   run:
     id: null # if `id` is None, a new run will be created
     name: null # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
     nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+
   params:
     dict_params:
       flatten: False  # if True, parameter which are dictionary will be splitted in multiple parameters when logged in mlflow, one for each key.
@@ -175,11 +180,12 @@ Mlflow enable the user to create "experiments" to organize his work. The differe
 ```yaml
 tracking:
   experiment:
-    name: <your-experiment-name>  # by default, the name of your python package in your kedro project
+    name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 ```
-
-Note that by default, mlflow crashes if you try to start a run while you have not created the experiment first. `kedro-mlflow` has a `create` key (`True` by default) which forces the creation of the experiment if it does not exist. Set it to `False` to match mlflow default value.
 
 ### Configure the run
 
@@ -191,8 +197,8 @@ The `mlflow.yml` accepts the following keys:
 tracking:
   run:
     id: null # if `id` is None, a new run will be created
-    name: null # if `name` is None, pipeline name will be used for the run name
-    nested: True  # # if `nested` is False, you won't be able to launch sub-runs inside your nodes
+    name: null # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
+    nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
 ```
 
 ```{tip}

--- a/kedro_mlflow/template/project/mlflow.yml
+++ b/kedro_mlflow/template/project/mlflow.yml
@@ -36,6 +36,9 @@ tracking:
 
   experiment:
     name: {{ python_package }}
+    create_experiment_kwargs: # will be used only if the experiment does not exist yet and is created.
+      artifact_location: null # enable to specify an artifact location for the experiment different than the global one for the mlflow server
+      tags: null  # a dict of tags for the experiment
     restore_if_deleted: True  # if the experiment`name` was previously deleted experiment, should we restore it?
 
   run:

--- a/tests/config/test_get_mlflow_config.py
+++ b/tests/config/test_get_mlflow_config.py
@@ -39,7 +39,11 @@ def test_mlflow_config_default(kedro_project):
                 pipelines=["my_disabled_pipeline"],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_package", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_package",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(
                 dict_params=dict(
@@ -81,7 +85,11 @@ def test_mlflow_config_in_uninitialized_project(kedro_project, package_name):
                 pipelines=[],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -111,7 +119,11 @@ def test_mlflow_config_with_no_experiment_name(kedro_project):
                 pipelines=[],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -225,7 +237,11 @@ def test_mlflow_config_correctly_set(kedro_project, project_settings):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[], disable_autologging=True),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
@@ -251,7 +267,11 @@ def test_mlflow_config_interpolated_with_globals_resolver(monkeypatch, fake_proj
                 pipelines=["my_disabled_pipeline"],
                 disable_autologging=True,
             ),
-            experiment=dict(name="fake_package", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_package",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id="123456789", name="my_run", nested=True),
             params=dict(
                 dict_params=dict(
@@ -318,7 +338,11 @@ class CustomRequestHeaderProvider(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -377,7 +401,11 @@ class CustomRequestHeaderProviderInitKwargs(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -440,7 +468,11 @@ class CustomRequestHeaderProviderInitKwargsKedroContext(RequestHeaderProvider):
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(
@@ -495,7 +527,11 @@ class BadCustomRequestHeaderProvider():
         ),
         tracking=dict(
             disable_tracking=dict(pipelines=[]),
-            experiment=dict(name="Default", restore_if_deleted=True),
+            experiment=dict(
+                name="Default",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             run=dict(id=None, name=None, nested=True),
             params=dict(
                 dict_params=dict(

--- a/tests/template/project/test_mlflow_yml.py
+++ b/tests/template/project/test_mlflow_yml.py
@@ -34,7 +34,11 @@ def test_mlflow_yml_rendering(template_mlflowyml):
         project_path="fake/path",
         tracking=dict(
             disable_tracking=dict(pipelines=[], disable_autologging=True),
-            experiment=dict(name="fake_project", restore_if_deleted=True),
+            experiment=dict(
+                name="fake_project",
+                create_experiment_kwargs=dict(artifact_location=None, tags=None),
+                restore_if_deleted=True,
+            ),
             params=dict(
                 dict_params=dict(flatten=False, recursive=True, sep="."),
                 long_params_strategy="fail",


### PR DESCRIPTION

## Description
Why was this PR created?

## Development notes
What have you changed, and how has this been tested?

## Checklist

- [ ] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
