### PR TITLE
Fix `run_id` logging error while loading `MlflowModelRegistryDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- :bug: Fix `run_id` logging error while loading `MlflowModelRegistryDataset` ([#671](https://github.com/Galileo-Galilei/kedro-mlflow/pull/671))
+
 ## [1.0.0] - 2025-07-27
 
 ### Added

--- a/kedro_mlflow/io/models/mlflow_model_registry_dataset.py
+++ b/kedro_mlflow/io/models/mlflow_model_registry_dataset.py
@@ -94,8 +94,12 @@ class MlflowModelRegistryDataset(MlflowAbstractModelDataSet):
         # the model itself does not have information about its registry
         # because the same run can be registered under several different names
         #  in the registry. See https://github.com/Galileo-Galilei/kedro-mlflow/issues/552
-
-        self._logger.info(f"Loading model from run_id='{model.metadata.run_id}'")
+        if (
+            model is not None
+            and hasattr(model, "metadata")
+            and hasattr(model.metadata, "run_id")
+        ):
+            self._logger.info(f"Loading model from run_id='{model.metadata.run_id}'")
         return model
 
     def _save(self, model: Any) -> None:


### PR DESCRIPTION
## Description

Resolves #670 

## Development notes

* Added conditional check before logging `run_id` in `kedro_mlflow/io/models/mlflow_model_registry_dataset.py`

## Checklist

- [x] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
