### PR TITLE
:bug: Enable PipelineML logging with custom model name ([#683](https:…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   :bug: Enable `PipelineML` logging with either custom model `name` following MLflow v3 convention, or custom `artifact_path` for back-compatibility with older MLflow versions. ([#683](https://github.com/Galileo-Galilei/kedro-mlflow/issues/683))
+
 ## [2.0.0] - 2025-11-25
 
 ### Added

--- a/kedro_mlflow/pipeline/pipeline_ml.py
+++ b/kedro_mlflow/pipeline/pipeline_ml.py
@@ -34,7 +34,7 @@ class PipelineML(Pipeline):
     """
 
     KPM_KWARGS_DEFAULT = {}
-    LOG_MODEL_KWARGS_DEFAULT = {"signature": "auto", "artifact_path": "model"}
+    LOG_MODEL_KWARGS_DEFAULT = {"signature": "auto", "name": "model"}
 
     def __init__(
         self,
@@ -85,6 +85,16 @@ class PipelineML(Pipeline):
         self.kpm_kwargs = {**self.KPM_KWARGS_DEFAULT, **kpm_kwargs}
 
         log_model_kwargs = log_model_kwargs or {}
+        if "name" in log_model_kwargs and "artifact_path" in log_model_kwargs:
+            raise KedroMlflowPipelineMLError(
+                "Both 'artifact_path' (deprecated in MLflow v3) and 'name' "
+                "parameters were specified. Please only specify 'name'."
+            )
+        elif "artifact_path" in log_model_kwargs:
+            self._logger.warning(
+                "'artifact_path' is deprecated in MLflow v3. Please use 'name' instead."
+            )
+            log_model_kwargs["name"] = log_model_kwargs.pop("artifact_path")
         self.log_model_kwargs = {**self.LOG_MODEL_KWARGS_DEFAULT, **log_model_kwargs}
         self._check_consistency()
 

--- a/tests/framework/hooks/test_hook_pipeline_ml.py
+++ b/tests/framework/hooks/test_hook_pipeline_ml.py
@@ -82,7 +82,7 @@ def dummy_pipeline_ml(dummy_pipeline, env_from_dict):
         training=dummy_pipeline.only_nodes_with_tags("training"),
         inference=dummy_pipeline.only_nodes_with_tags("inference"),
         input_name="raw_data",
-        log_model_kwargs={"conda_env": env_from_dict, "artifact_path": "model"},
+        log_model_kwargs={"conda_env": env_from_dict, "name": "model"},
     )
     return dummy_pipeline_ml
 
@@ -371,7 +371,7 @@ def test_mlflow_hook_save_pipeline_ml_with_copy_mode(
             inference=dummy_pipeline_ml.inference,
             input_name=dummy_pipeline_ml.input_name,
             log_model_kwargs={
-                "artifact_path": dummy_pipeline_ml.log_model_kwargs["artifact_path"],
+                "name": dummy_pipeline_ml.log_model_kwargs["name"],
                 "conda_env": {"python": "3.10.0", "dependencies": ["kedro==0.18.11"]},
             },
             kpm_kwargs={
@@ -431,7 +431,7 @@ def test_mlflow_hook_save_pipeline_ml_with_default_copy_mode_assign(
             inference=dummy_pipeline_ml.inference,
             input_name=dummy_pipeline_ml.input_name,
             log_model_kwargs={
-                "artifact_path": dummy_pipeline_ml.log_model_kwargs["artifact_path"],
+                "name": dummy_pipeline_ml.log_model_kwargs["name"],
                 "conda_env": {"python": "3.10.0", "dependencies": ["kedro==0.18.11"]},
             },
         )
@@ -578,17 +578,17 @@ def test_mlflow_hook_save_pipeline_ml_with_signature(
 
 
 @pytest.mark.parametrize(
-    "artifact_path,expected_artifact_path",
+    "name,expected_name",
     ([None, "model"], ["my_custom_model", "my_custom_model"]),
 )
-def test_mlflow_hook_save_pipeline_ml_with_artifact_path(
+def test_mlflow_hook_save_pipeline_ml_with_name(
     kedro_project_with_mlflow_conf,
     env_from_dict,
     dummy_pipeline,
     dummy_catalog,
     dummy_run_params,
-    artifact_path,
-    expected_artifact_path,
+    name,
+    expected_name,
 ):
     # config_with_base_mlflow_conf is a conftest fixture
     bootstrap_project(kedro_project_with_mlflow_conf)
@@ -599,9 +599,9 @@ def test_mlflow_hook_save_pipeline_ml_with_artifact_path(
         log_model_kwargs = {
             "conda_env": env_from_dict,
         }
-        if artifact_path is not None:
+        if name is not None:
             # we need to test what happens if the key is NOT present
-            log_model_kwargs["artifact_path"] = artifact_path
+            log_model_kwargs["name"] = name
 
         pipeline_to_run = pipeline_ml_factory(
             training=dummy_pipeline.only_nodes_with_tags("training"),
@@ -634,9 +634,7 @@ def test_mlflow_hook_save_pipeline_ml_with_artifact_path(
         )
 
         # test : parameters should have been logged
-        trained_model = mlflow.pyfunc.load_model(
-            f"runs:/{run_id}/{expected_artifact_path}"
-        )
+        trained_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/{expected_name}")
         # the real test is that the model is loaded without error
         assert trained_model is not None
 
@@ -663,7 +661,7 @@ def test_mlflow_hook_save_pipeline_ml_with_dataset_factory(
         }
 
         namespace = "a"
-        log_model_kwargs["artifact_path"] = "artifacts"
+        log_model_kwargs["name"] = "artifacts"
         dummy_pipeline_with_namespace = pipeline(
             nodes=dummy_pipeline_dataset_factory, namespace=namespace
         )


### PR DESCRIPTION
…//github.com/Galileo-Galilei/kedro-mlflow/issues/683))

## Description
This PR was created to fix the MLflowException encountered when providing a custom model `name` to `log_model_kwargs` parameter of `pipeline_ml_factory`. ([#683](https://github.com/Galileo-Galilei/kedro-mlflow/issues/683))

## Development notes
- Changed the `artifact_path` key into `name` in the default log_model_kwargs of PipelineML
- Added a conditional block in `PipelineML` to accept the case where the user provides only the deprecated `artifact_path`, but not when the user provides both `name` and `artifact_path`.
- Added test cases for the above scenarios in test_pipeline_ml.py
- Updated tests in test_hook_pipeline_ml.py to use `name` parameter instead of `artifact_path`.

## Checklist

- [X] Read the [contributing](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Update the documentation to reflect the code changes
- [X] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](https://github.com/Galileo-Galilei/kedro-mlflow/blob/master/CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [X] Add tests to cover your changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
